### PR TITLE
Improve duration attr

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
-	"log/slog"
 	"testing"
 )
 
@@ -142,7 +141,7 @@ var (
 
 func TestWithMockErrorConn(t *testing.T) {
 	t.Parallel()
-	logger := newStepLogger(slog.Default(), nil)
+	logger := newStepLogger(nil)
 	connOptions := defaultConnOptions("sqlite3", StepLogMsgWithoutEventName)
 	w := wrapConn(newMockErrConn(errors.New("unexpected error")), logger, connOptions)
 	t.Run("Begin", func(t *testing.T) {
@@ -173,7 +172,7 @@ func TestWithMockErrorConn(t *testing.T) {
 
 func TestPingInCase(t *testing.T) {
 	t.Parallel()
-	logger := newStepLogger(slog.Default(), nil)
+	logger := newStepLogger(nil)
 	conn := newMockErrConn(nil)
 	w := &connWithContextWrapper{
 		connWrapper: connWrapper{

--- a/conn_test.go
+++ b/conn_test.go
@@ -142,7 +142,7 @@ var (
 
 func TestWithMockErrorConn(t *testing.T) {
 	t.Parallel()
-	logger := newStepLogger(slog.Default(), newOptions("sqlite3"))
+	logger := newStepLogger(slog.Default(), nil)
 	connOptions := defaultConnOptions("sqlite3", StepLogMsgWithoutEventName)
 	w := wrapConn(newMockErrConn(errors.New("unexpected error")), logger, connOptions)
 	t.Run("Begin", func(t *testing.T) {
@@ -173,7 +173,7 @@ func TestWithMockErrorConn(t *testing.T) {
 
 func TestPingInCase(t *testing.T) {
 	t.Parallel()
-	logger := newStepLogger(slog.Default(), newOptions("sqlite3"))
+	logger := newStepLogger(slog.Default(), nil)
 	conn := newMockErrConn(nil)
 	w := &connWithContextWrapper{
 		connWrapper: connWrapper{

--- a/driver_test.go
+++ b/driver_test.go
@@ -33,7 +33,7 @@ func TestDriverContextWrapperOpenConnector(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		logger := slog.New(NewTextHandler(buf, nil))
 		dw := wrapDriver(&mockErrorDiverContext{},
-			newStepLogger(logger, nil),
+			newStepLogger(newStepLoggerOptions(logger)),
 			defaultDriverOptions("sqlite3", StepLogMsgWithoutEventName),
 		)
 		dwc, ok := dw.(driver.DriverContext)

--- a/driver_test.go
+++ b/driver_test.go
@@ -33,7 +33,7 @@ func TestDriverContextWrapperOpenConnector(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		logger := slog.New(NewTextHandler(buf, nil))
 		dw := wrapDriver(&mockErrorDiverContext{},
-			newStepLogger(logger, newOptions("sqlite3")),
+			newStepLogger(logger, nil),
 			defaultDriverOptions("sqlite3", StepLogMsgWithoutEventName),
 		)
 		dwc, ok := dw.(driver.DriverContext)

--- a/duration.go
+++ b/duration.go
@@ -14,7 +14,7 @@ const (
 // The default is DurationNanoSeconds.
 func Duration(v DurationType) Option {
 	return func(o *options) {
-		o.durationType = v
+		o.stepLoggerOptions.durationType = v
 	}
 }
 
@@ -22,7 +22,7 @@ func Duration(v DurationType) Option {
 // The default is specified by DurationKeyDefault.
 func DurationKey(key string) Option {
 	return func(o *options) {
-		o.durationKey = key
+		o.stepLoggerOptions.durationKey = key
 	}
 }
 

--- a/open.go
+++ b/open.go
@@ -43,7 +43,8 @@ See the following example for usage:
 */
 func Open(ctx context.Context, driverName, dsn string, opts ...Option) (*sql.DB, error) { // nolint:funlen
 	options := newOptions(driverName, opts...)
-	logger := newStepLogger(options.logger, &stepLoggerOptions{
+	logger := newStepLogger(&stepLoggerOptions{
+		logger:       options.logger,
 		durationKey:  options.durationKey,
 		durationType: options.durationType,
 	})

--- a/open.go
+++ b/open.go
@@ -43,7 +43,10 @@ See the following example for usage:
 */
 func Open(ctx context.Context, driverName, dsn string, opts ...Option) (*sql.DB, error) { // nolint:funlen
 	options := newOptions(driverName, opts...)
-	logger := newStepLogger(options.logger, options)
+	logger := newStepLogger(options.logger, &stepLoggerOptions{
+		durationKey:  options.durationKey,
+		durationType: options.durationType,
+	})
 
 	return open(ctx, driverName, dsn, logger, &options.sqlslogOptions)
 }

--- a/open_test.go
+++ b/open_test.go
@@ -56,7 +56,7 @@ func TestOpenWithDriver(t *testing.T) {
 		t.Parallel()
 		t.Run("DriverContext", func(t *testing.T) {
 			drv := newErrorDriverContext(errors.New("unknown error"))
-			stepLogger := newStepLogger(slog.New(slog.NewJSONHandler(nil, nil)), nil)
+			stepLogger := newStepLogger(newStepLoggerOptions(slog.New(slog.NewJSONHandler(nil, nil))))
 			if _, err := openWithWrappedDriver(drv, "invalid-dsn", stepLogger, nil); err == nil {
 				t.Fatal("Expected error")
 			}

--- a/options.go
+++ b/options.go
@@ -41,7 +41,7 @@ func newOptions(driverName string, opts ...Option) *options {
 // If not set, the default is slog.Default().
 func Logger(logger *slog.Logger) Option {
 	return func(o *options) {
-		o.logger = logger
+		o.stepLoggerOptions.logger = logger
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -5,20 +5,17 @@ import (
 )
 
 type options struct {
-	logger *slog.Logger
-
-	durationKey  string
-	durationType DurationType
-
+	stepLoggerOptions
 	sqlslogOptions
 }
 
 func newDefaultOptions(driverName string, formatter StepLogMsgFormatter) *options {
 	return &options{
-		logger:       slog.Default(),
-		durationKey:  DurationKeyDefault,
-		durationType: DurationNanoSeconds,
-
+		stepLoggerOptions: stepLoggerOptions{
+			logger:       slog.Default(),
+			durationKey:  DurationKeyDefault,
+			durationType: DurationNanoSeconds,
+		},
 		sqlslogOptions: *defaultSqlslogOptions(driverName, formatter),
 	}
 }

--- a/rows_test.go
+++ b/rows_test.go
@@ -90,7 +90,7 @@ func TestRowsNextResultSet(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	logger := slog.New(NewJSONHandler(buf, nil))
 	rowsOptions := defaultRowsOptions(StepLogMsgWithoutEventName)
-	wrapped := wrapRows(rows, newStepLogger(logger, newOptions("dummy")), rowsOptions)
+	wrapped := wrapRows(rows, newStepLogger(logger, nil), rowsOptions)
 	wrappedRNRS, ok := wrapped.(driver.RowsNextResultSet)
 	if !ok {
 		t.Fatal("Expected true")

--- a/rows_test.go
+++ b/rows_test.go
@@ -36,7 +36,7 @@ func (m *mockRows) Next([]driver.Value) error {
 
 func TestWithMockRows(t *testing.T) {
 	t.Parallel()
-	wrapped := &rowsWrapper{original: &mockRows{}, logger: newStepLogger(slog.Default(), nil)}
+	wrapped := &rowsWrapper{original: &mockRows{}, logger: newStepLogger(nil)}
 	t.Run("ColumnTypeScanType", func(t *testing.T) {
 		t.Parallel()
 		res := wrapped.ColumnTypeScanType(0)
@@ -90,7 +90,7 @@ func TestRowsNextResultSet(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	logger := slog.New(NewJSONHandler(buf, nil))
 	rowsOptions := defaultRowsOptions(StepLogMsgWithoutEventName)
-	wrapped := wrapRows(rows, newStepLogger(logger, nil), rowsOptions)
+	wrapped := wrapRows(rows, newStepLogger(newStepLoggerOptions(logger)), rowsOptions)
 	wrappedRNRS, ok := wrapped.(driver.RowsNextResultSet)
 	if !ok {
 		t.Fatal("Expected true")

--- a/step_logger.go
+++ b/step_logger.go
@@ -7,12 +7,14 @@ import (
 )
 
 type stepLoggerOptions struct {
+	logger       *slog.Logger
 	durationKey  string
 	durationType DurationType
 }
 
-func newStepLoggerOptions() *stepLoggerOptions {
+func newStepLoggerOptions(logger *slog.Logger) *stepLoggerOptions {
 	return &stepLoggerOptions{
+		logger:       logger,
 		durationKey:  DurationKeyDefault,
 		durationType: DurationNanoSeconds,
 	}
@@ -20,13 +22,16 @@ func newStepLoggerOptions() *stepLoggerOptions {
 
 type stepLogger struct {
 	*slog.Logger
-
 	durationAttr func(d time.Duration) slog.Attr
 }
 
-func newStepLogger(rawLogger *slog.Logger, opts *stepLoggerOptions) *stepLogger {
+func newStepLogger(opts *stepLoggerOptions) *stepLogger {
 	if opts == nil {
-		opts = newStepLoggerOptions()
+		opts = newStepLoggerOptions(nil)
+	}
+	rawLogger := opts.logger
+	if rawLogger == nil {
+		rawLogger = slog.Default()
 	}
 	return &stepLogger{
 		Logger:       rawLogger,

--- a/step_logger_test.go
+++ b/step_logger_test.go
@@ -88,7 +88,7 @@ func TestStepLoggerDurationAttr(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.value.String(), func(t *testing.T) {
 			t.Parallel()
-			attr := newStepLogger(nil, &stepLoggerOptions{durationKey: key, durationType: tc.durationType}).durationAttr(tc.value)
+			attr := newStepLogger(&stepLoggerOptions{durationKey: key, durationType: tc.durationType}).durationAttr(tc.value)
 			tc.expected(t, attr)
 		})
 	}

--- a/step_logger_test.go
+++ b/step_logger_test.go
@@ -88,7 +88,7 @@ func TestStepLoggerDurationAttr(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.value.String(), func(t *testing.T) {
 			t.Parallel()
-			attr := newStepLogger(nil, &options{durationKey: key, durationType: tc.durationType}).durationAttr(tc.value)
+			attr := newStepLogger(nil, &stepLoggerOptions{durationKey: key, durationType: tc.durationType}).durationAttr(tc.value)
 			tc.expected(t, attr)
 		})
 	}

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -62,7 +62,7 @@ func TestWrapStmt(t *testing.T) {
 
 		buf := bytes.NewBuffer(nil)
 		logger := slog.New(NewJSONHandler(buf, nil))
-		wrapped := wrapStmt(mock, newStepLogger(logger, newOptions("dummy")), defaultStmtOptions(StepLogMsgWithoutEventName))
+		wrapped := wrapStmt(mock, newStepLogger(logger, nil), defaultStmtOptions(StepLogMsgWithoutEventName))
 		_, err := wrapped.Query(nil) // nolint:staticcheck
 		if err == nil {
 			t.Fatal("Expected non-nil")
@@ -102,7 +102,7 @@ func TestWithMockErrorStmtWithContext(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 	logger := slog.New(NewJSONHandler(buf, nil))
-	wrapped := wrapStmt(mock, newStepLogger(logger, newOptions("dummy")), defaultStmtOptions(StepLogMsgWithoutEventName))
+	wrapped := wrapStmt(mock, newStepLogger(logger, nil), defaultStmtOptions(StepLogMsgWithoutEventName))
 	stmtWithQueryContext, ok := wrapped.(driver.StmtQueryContext)
 	if !ok {
 		t.Fatal("Expected StmtQueryContext")

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -62,7 +62,7 @@ func TestWrapStmt(t *testing.T) {
 
 		buf := bytes.NewBuffer(nil)
 		logger := slog.New(NewJSONHandler(buf, nil))
-		wrapped := wrapStmt(mock, newStepLogger(logger, nil), defaultStmtOptions(StepLogMsgWithoutEventName))
+		wrapped := wrapStmt(mock, newStepLogger(newStepLoggerOptions(logger)), defaultStmtOptions(StepLogMsgWithoutEventName))
 		_, err := wrapped.Query(nil) // nolint:staticcheck
 		if err == nil {
 			t.Fatal("Expected non-nil")
@@ -102,7 +102,7 @@ func TestWithMockErrorStmtWithContext(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 	logger := slog.New(NewJSONHandler(buf, nil))
-	wrapped := wrapStmt(mock, newStepLogger(logger, nil), defaultStmtOptions(StepLogMsgWithoutEventName))
+	wrapped := wrapStmt(mock, newStepLogger(newStepLoggerOptions(logger)), defaultStmtOptions(StepLogMsgWithoutEventName))
 	stmtWithQueryContext, ok := wrapped.(driver.StmtQueryContext)
 	if !ok {
 		t.Fatal("Expected StmtQueryContext")


### PR DESCRIPTION
- Modify stepLogger.durationAttr from method to field
    - The field does not have if statement inside
- Define stepLoggerOptions 
- Use stepLoggerOptions instead of options in stepLogger
- Embed stepLoggerOptions into options type
