### PR TITLE
Define step type explicitly

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -39,24 +39,24 @@ func defaultConnOptions(driverName string, formatter StepLogMsgFormatter) *connO
 	return &connOptions{
 		IDGen: IDGeneratorDefault,
 
-		Begin:     *defaultStepOptions(formatter, "Conn.Begin", LevelInfo),
-		BeginTx:   *defaultStepOptions(formatter, "Conn.BeginTx", LevelInfo),
+		Begin:     *defaultStepOptions(formatter, StepConnBegin, LevelInfo),
+		BeginTx:   *defaultStepOptions(formatter, StepConnBeginTx, LevelInfo),
 		TxIDKey:   TxIDKeyDefault,
 		TxOptions: defaultTxOptions(formatter),
 
-		Close: *defaultStepOptions(formatter, "Conn.Close", LevelInfo),
+		Close: *defaultStepOptions(formatter, StepConnClose, LevelInfo),
 
-		Prepare:        *defaultStepOptions(formatter, "Conn.Prepare", LevelInfo),
-		PrepareContext: *defaultStepOptions(formatter, "Conn.PrepareContext", LevelInfo),
+		Prepare:        *defaultStepOptions(formatter, StepConnPrepare, LevelInfo),
+		PrepareContext: *defaultStepOptions(formatter, StepConnPrepareContext, LevelInfo),
 		StmtIDKey:      StmtIDKeyDefault,
 		StmtOptions:    stmtOptions,
 
-		ResetSession: *defaultStepOptions(formatter, "Conn.ResetSession", LevelTrace),
-		Ping:         *defaultStepOptions(formatter, "Conn.Ping", LevelTrace),
+		ResetSession: *defaultStepOptions(formatter, StepConnResetSession, LevelTrace),
+		Ping:         *defaultStepOptions(formatter, StepConnPing, LevelTrace),
 
-		ExecContext: *defaultStepOptions(formatter, "Conn.ExecContext", LevelInfo, ConnExecContextErrorHandler(driverName)),
+		ExecContext: *defaultStepOptions(formatter, StepConnExecContext, LevelInfo, ConnExecContextErrorHandler(driverName)),
 
-		QueryContext: *defaultStepOptions(formatter, "Conn.QueryContext", LevelInfo, ConnQueryContextErrorHandler(driverName)),
+		QueryContext: *defaultStepOptions(formatter, StepConnQueryContext, LevelInfo, ConnQueryContextErrorHandler(driverName)),
 		RowsOptions:  rowsOptions,
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -32,31 +32,31 @@ type connOptions struct {
 	RowsOptions  *rowsOptions
 }
 
-func defaultConnOptions(driverName string, formatter StepEventMsgBuilder) *connOptions {
-	stmtOptions := defaultStmtOptions(formatter)
+func defaultConnOptions(driverName string, msgb StepEventMsgBuilder) *connOptions {
+	stmtOptions := defaultStmtOptions(msgb)
 	rowsOptions := stmtOptions.Rows
 
 	return &connOptions{
 		IDGen: IDGeneratorDefault,
 
-		Begin:     *defaultStepOptions(formatter, StepConnBegin, LevelInfo),
-		BeginTx:   *defaultStepOptions(formatter, StepConnBeginTx, LevelInfo),
+		Begin:     *defaultStepOptions(msgb, StepConnBegin, LevelInfo),
+		BeginTx:   *defaultStepOptions(msgb, StepConnBeginTx, LevelInfo),
 		TxIDKey:   TxIDKeyDefault,
-		TxOptions: defaultTxOptions(formatter),
+		TxOptions: defaultTxOptions(msgb),
 
-		Close: *defaultStepOptions(formatter, StepConnClose, LevelInfo),
+		Close: *defaultStepOptions(msgb, StepConnClose, LevelInfo),
 
-		Prepare:        *defaultStepOptions(formatter, StepConnPrepare, LevelInfo),
-		PrepareContext: *defaultStepOptions(formatter, StepConnPrepareContext, LevelInfo),
+		Prepare:        *defaultStepOptions(msgb, StepConnPrepare, LevelInfo),
+		PrepareContext: *defaultStepOptions(msgb, StepConnPrepareContext, LevelInfo),
 		StmtIDKey:      StmtIDKeyDefault,
 		StmtOptions:    stmtOptions,
 
-		ResetSession: *defaultStepOptions(formatter, StepConnResetSession, LevelTrace),
-		Ping:         *defaultStepOptions(formatter, StepConnPing, LevelTrace),
+		ResetSession: *defaultStepOptions(msgb, StepConnResetSession, LevelTrace),
+		Ping:         *defaultStepOptions(msgb, StepConnPing, LevelTrace),
 
-		ExecContext: *defaultStepOptions(formatter, StepConnExecContext, LevelInfo, ConnExecContextErrorHandler(driverName)),
+		ExecContext: *defaultStepOptions(msgb, StepConnExecContext, LevelInfo, ConnExecContextErrorHandler(driverName)),
 
-		QueryContext: *defaultStepOptions(formatter, StepConnQueryContext, LevelInfo, ConnQueryContextErrorHandler(driverName)),
+		QueryContext: *defaultStepOptions(msgb, StepConnQueryContext, LevelInfo, ConnQueryContextErrorHandler(driverName)),
 		RowsOptions:  rowsOptions,
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -32,7 +32,7 @@ type connOptions struct {
 	RowsOptions  *rowsOptions
 }
 
-func defaultConnOptions(driverName string, formatter StepLogMsgFormatter) *connOptions {
+func defaultConnOptions(driverName string, formatter StepEventMsgBuilder) *connOptions {
 	stmtOptions := defaultStmtOptions(formatter)
 	rowsOptions := stmtOptions.Rows
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -38,7 +38,7 @@ func TestWrapConn(t *testing.T) {
 		t.Parallel()
 		mock := &mockConnForWrapConn{}
 		logger := &stepLogger{}
-		connOptions := defaultConnOptions("dummy", StepLogMsgWithoutEventName)
+		connOptions := defaultConnOptions("dummy", StepEventMsgWithoutEventName)
 		conn := wrapConn(mock, logger, connOptions)
 		if conn == nil {
 			t.Fatal("Expected non-nil")
@@ -142,7 +142,7 @@ var (
 func TestWithMockErrorConn(t *testing.T) {
 	t.Parallel()
 	logger := newStepLogger(nil)
-	connOptions := defaultConnOptions("sqlite3", StepLogMsgWithoutEventName)
+	connOptions := defaultConnOptions("sqlite3", StepEventMsgWithoutEventName)
 	w := wrapConn(newMockErrConn(errors.New("unexpected error")), logger, connOptions)
 	t.Run("Begin", func(t *testing.T) {
 		t.Parallel()
@@ -178,7 +178,7 @@ func TestPingInCase(t *testing.T) {
 		connWrapper: connWrapper{
 			original: conn,
 			logger:   logger,
-			options:  defaultConnOptions("sqlite3", StepLogMsgWithoutEventName),
+			options:  defaultConnOptions("sqlite3", StepEventMsgWithoutEventName),
 		},
 		originalConn: conn,
 	}

--- a/connector.go
+++ b/connector.go
@@ -13,7 +13,7 @@ type connectorOptions struct {
 	ConnOptions *connOptions
 }
 
-func defaultConnectorOptions(driver string, formatter StepLogMsgFormatter) *connectorOptions {
+func defaultConnectorOptions(driver string, formatter StepEventMsgBuilder) *connectorOptions {
 	return &connectorOptions{
 		Connect:     *defaultStepOptions(formatter, StepConnectorConnect, LevelInfo),
 		ConnOptions: defaultConnOptions(driver, formatter),

--- a/connector.go
+++ b/connector.go
@@ -13,10 +13,10 @@ type connectorOptions struct {
 	ConnOptions *connOptions
 }
 
-func defaultConnectorOptions(driver string, formatter StepEventMsgBuilder) *connectorOptions {
+func defaultConnectorOptions(driver string, msgb StepEventMsgBuilder) *connectorOptions {
 	return &connectorOptions{
-		Connect:     *defaultStepOptions(formatter, StepConnectorConnect, LevelInfo),
-		ConnOptions: defaultConnOptions(driver, formatter),
+		Connect:     *defaultStepOptions(msgb, StepConnectorConnect, LevelInfo),
+		ConnOptions: defaultConnOptions(driver, msgb),
 	}
 }
 

--- a/connector.go
+++ b/connector.go
@@ -15,7 +15,7 @@ type connectorOptions struct {
 
 func defaultConnectorOptions(driver string, formatter StepLogMsgFormatter) *connectorOptions {
 	return &connectorOptions{
-		Connect:     *defaultStepOptions(formatter, "Connector.Connect", LevelInfo),
+		Connect:     *defaultStepOptions(formatter, StepConnectorConnect, LevelInfo),
 		ConnOptions: defaultConnOptions(driver, formatter),
 	}
 }

--- a/connector_test.go
+++ b/connector_test.go
@@ -87,7 +87,7 @@ func TestConnectorDriver(t *testing.T) {
 	t.Parallel()
 	mock := &mockConnectorForWrapConnector{}
 	logger := &stepLogger{}
-	connectorOptions := defaultConnectorOptions("dummy", StepLogMsgWithoutEventName)
+	connectorOptions := defaultConnectorOptions("dummy", StepEventMsgWithoutEventName)
 	conn := wrapConnector(mock, logger, connectorOptions)
 	if conn.Driver() != nil {
 		t.Fatal("Expected nil")

--- a/doc.go
+++ b/doc.go
@@ -28,20 +28,17 @@ sqlslog has 6 log levels: [LevelVerbose], [LevelTrace], [LevelDebug], [LevelInfo
 [LevelVerbose] and [LevelTrace] are extra log levels for sqlslog.
 [LevelVerbose] is the lowest log level, and [LevelTrace] is the second lowest log level.
 
-# Step
+# Step and Event
 
-In sqlslog terms, a step is a logical operation in the database driver, such as a query, a ping, a prepare, etc.
-
-A step has three events: start, error, and complete.
-
-sqlslog provides a way to customize the log message and log level for each step event.
-
+A [Step] is a logical operation in the database driver, such as a query, a ping, a prepare, etc.
+An [Event] is an event that occurs during a [Step], such as [EventStart], [EventError], and [EventComplete].
+A [StepOptions] is a set of options for logging a [Step] and has [EventOptions] for each event.
+sqlslog provides a way to customize the log message and log [Level] for each step event.
 You can customize them by using functions that take [StepOptions] and return [Option], like [ConnPrepareContext] or [StmtQueryContext].
 
 # Default Step Log Message Formatter
 
 The default step log message formatter is [StepLogMsgWithEventName].
-
 You can change the default step log message formatter by calling [SetStepLogMsgFormatter].
 
 # Tracking ID

--- a/doc.go
+++ b/doc.go
@@ -38,7 +38,7 @@ You can customize them by using functions that take [StepOptions] and return [Op
 
 # Default Step Log Message Formatter
 
-The default step log message formatter is [StepLogMsgWithEventName].
+The default step log message formatter is [StepEventMsgWithEventName].
 You can change the default step log message formatter by calling [SetStepLogMsgFormatter].
 
 # Tracking ID

--- a/doc.go
+++ b/doc.go
@@ -36,10 +36,10 @@ A [StepOptions] is a set of options for logging a [Step] and has [EventOptions] 
 sqlslog provides a way to customize the log message and log [Level] for each step event.
 You can customize them by using functions that take [StepOptions] and return [Option], like [ConnPrepareContext] or [StmtQueryContext].
 
-# Default Step Log Message Formatter
+# DefaultStepEventMsgBuilder
 
-The default step log message formatter is [StepEventMsgWithEventName].
-You can change the default step log message formatter by calling [SetStepLogMsgFormatter].
+The default step event message builder is [StepEventMsgWithEventName].
+You can change the default step event message builder by calling [SetStepEventMsgBuilder].
 
 # Tracking ID
 

--- a/driver.go
+++ b/driver.go
@@ -17,15 +17,15 @@ type driverOptions struct {
 	ConnectorOptions *connectorOptions
 }
 
-func defaultDriverOptions(driverName string, formatter StepEventMsgBuilder) *driverOptions {
-	connectorOptions := defaultConnectorOptions(driverName, formatter)
+func defaultDriverOptions(driverName string, msgb StepEventMsgBuilder) *driverOptions {
+	connectorOptions := defaultConnectorOptions(driverName, msgb)
 	connOptions := connectorOptions.ConnOptions
 	return &driverOptions{
 		IDGen:     IDGeneratorDefault,
 		ConnIDKey: "conn_id",
 
-		Open:          *defaultStepOptions(formatter, StepDriverOpen, LevelInfo),
-		OpenConnector: *defaultStepOptions(formatter, StepDriverOpenConnector, LevelInfo),
+		Open:          *defaultStepOptions(msgb, StepDriverOpen, LevelInfo),
+		OpenConnector: *defaultStepOptions(msgb, StepDriverOpenConnector, LevelInfo),
 
 		ConnOptions:      connOptions,
 		ConnectorOptions: connectorOptions,

--- a/driver.go
+++ b/driver.go
@@ -17,7 +17,7 @@ type driverOptions struct {
 	ConnectorOptions *connectorOptions
 }
 
-func defaultDriverOptions(driverName string, formatter StepLogMsgFormatter) *driverOptions {
+func defaultDriverOptions(driverName string, formatter StepEventMsgBuilder) *driverOptions {
 	connectorOptions := defaultConnectorOptions(driverName, formatter)
 	connOptions := connectorOptions.ConnOptions
 	return &driverOptions{

--- a/driver.go
+++ b/driver.go
@@ -24,8 +24,8 @@ func defaultDriverOptions(driverName string, formatter StepLogMsgFormatter) *dri
 		IDGen:     IDGeneratorDefault,
 		ConnIDKey: "conn_id",
 
-		Open:          *defaultStepOptions(formatter, "Driver.Open", LevelInfo),
-		OpenConnector: *defaultStepOptions(formatter, "Driver.OpenConnector", LevelInfo),
+		Open:          *defaultStepOptions(formatter, StepDriverOpen, LevelInfo),
+		OpenConnector: *defaultStepOptions(formatter, StepDriverOpenConnector, LevelInfo),
 
 		ConnOptions:      connOptions,
 		ConnectorOptions: connectorOptions,

--- a/driver_test.go
+++ b/driver_test.go
@@ -34,7 +34,7 @@ func TestDriverContextWrapperOpenConnector(t *testing.T) {
 		logger := slog.New(NewTextHandler(buf, nil))
 		dw := wrapDriver(&mockErrorDiverContext{},
 			newStepLogger(newStepLoggerOptions(logger)),
-			defaultDriverOptions("sqlite3", StepLogMsgWithoutEventName),
+			defaultDriverOptions("sqlite3", StepEventMsgWithoutEventName),
 		)
 		dwc, ok := dw.(driver.DriverContext)
 		if !ok {

--- a/event.go
+++ b/event.go
@@ -1,0 +1,24 @@
+package sqlslog
+
+// Event is the event type of the step.
+type Event int
+
+const (
+	EventStart    Event = iota + 1 // Event when the step starts.
+	EventError                     // Event when the step ends with an error.
+	EventComplete                  // Event when the step completes successfully.
+)
+
+// String returns the string representation of the event.
+func (pe *Event) String() string {
+	switch *pe {
+	case EventStart:
+		return "Start"
+	case EventError:
+		return "Error"
+	case EventComplete:
+		return "Complete"
+	default:
+		return "Unknown"
+	}
+}

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,41 @@
+package sqlslog
+
+import "testing"
+
+func TestEventString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		e    Event
+		want string
+	}{
+		{
+			name: "EventStart",
+			e:    EventStart,
+			want: "Start",
+		},
+		{
+			name: "EventError",
+			e:    EventError,
+			want: "Error",
+		},
+		{
+			name: "EventComplete",
+			e:    EventComplete,
+			want: "Complete",
+		},
+		{
+			name: "Unknown",
+			e:    Event(0),
+			want: "Unknown",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.e.String(); got != tt.want {
+				t.Errorf("Event.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/open.go
+++ b/open.go
@@ -12,10 +12,10 @@ type sqlslogOptions struct {
 	DriverOptions *driverOptions
 }
 
-func defaultSqlslogOptions(driverName string, formatter StepEventMsgBuilder) *sqlslogOptions {
-	driverOptions := defaultDriverOptions(driverName, formatter)
+func defaultSqlslogOptions(driverName string, msgb StepEventMsgBuilder) *sqlslogOptions {
+	driverOptions := defaultDriverOptions(driverName, msgb)
 	return &sqlslogOptions{
-		Open:          *defaultStepOptions(formatter, StepSqlslogOpen, LevelInfo),
+		Open:          *defaultStepOptions(msgb, StepSqlslogOpen, LevelInfo),
 		DriverOptions: driverOptions,
 	}
 }
@@ -37,7 +37,7 @@ See the following example for usage:
 
 [StepOptions]: sets the options for logging behavior.
 
-[SetStepLogMsgFormatter]: sets the function to format the step name.
+[SetStepEventMsgBuilder]: sets the function to format the step name.
 
 [sql.Open]: https://pkg.go.dev/database/sql#Open
 */

--- a/open.go
+++ b/open.go
@@ -12,7 +12,7 @@ type sqlslogOptions struct {
 	DriverOptions *driverOptions
 }
 
-func defaultSqlslogOptions(driverName string, formatter StepLogMsgFormatter) *sqlslogOptions {
+func defaultSqlslogOptions(driverName string, formatter StepEventMsgBuilder) *sqlslogOptions {
 	driverOptions := defaultDriverOptions(driverName, formatter)
 	return &sqlslogOptions{
 		Open:          *defaultStepOptions(formatter, StepSqlslogOpen, LevelInfo),

--- a/open.go
+++ b/open.go
@@ -15,7 +15,7 @@ type sqlslogOptions struct {
 func defaultSqlslogOptions(driverName string, formatter StepLogMsgFormatter) *sqlslogOptions {
 	driverOptions := defaultDriverOptions(driverName, formatter)
 	return &sqlslogOptions{
-		Open:          *defaultStepOptions(formatter, "Open", LevelInfo),
+		Open:          *defaultStepOptions(formatter, StepSqlslogOpen, LevelInfo),
 		DriverOptions: driverOptions,
 	}
 }

--- a/options.go
+++ b/options.go
@@ -9,14 +9,14 @@ type options struct {
 	sqlslogOptions
 }
 
-func newDefaultOptions(driverName string, formatter StepEventMsgBuilder) *options {
+func newDefaultOptions(driverName string, msgb StepEventMsgBuilder) *options {
 	return &options{
 		stepLoggerOptions: stepLoggerOptions{
 			logger:       slog.Default(),
 			durationKey:  DurationKeyDefault,
 			durationType: DurationNanoSeconds,
 		},
-		sqlslogOptions: *defaultSqlslogOptions(driverName, formatter),
+		sqlslogOptions: *defaultSqlslogOptions(driverName, msgb),
 	}
 }
 
@@ -25,7 +25,7 @@ type Option func(*options)
 
 var stepEventMsgBuilder = StepEventMsgWithoutEventName
 
-// SetStepEventMsgBuilder sets the formatter for the step name used in logs.
+// SetStepEventMsgBuilder sets the builder for the step event message used in logs.
 // If not set, the default is StepLogMsgWithEventName.
 func SetStepEventMsgBuilder(f StepEventMsgBuilder) { stepEventMsgBuilder = f }
 

--- a/options.go
+++ b/options.go
@@ -23,14 +23,14 @@ func newDefaultOptions(driverName string, formatter StepEventMsgBuilder) *option
 // Option is a function that sets an option on the options struct.
 type Option func(*options)
 
-var stepLogMsgFormatter = StepEventMsgWithoutEventName
+var stepEventMsgBuilder = StepEventMsgWithoutEventName
 
-// SetStepLogMsgFormatter sets the formatter for the step name used in logs.
+// SetStepEventMsgBuilder sets the formatter for the step name used in logs.
 // If not set, the default is StepLogMsgWithEventName.
-func SetStepLogMsgFormatter(f StepEventMsgBuilder) { stepLogMsgFormatter = f }
+func SetStepEventMsgBuilder(f StepEventMsgBuilder) { stepEventMsgBuilder = f }
 
 func newOptions(driverName string, opts ...Option) *options {
-	o := newDefaultOptions(driverName, stepLogMsgFormatter)
+	o := newDefaultOptions(driverName, stepEventMsgBuilder)
 	for _, opt := range opts {
 		opt(o)
 	}

--- a/options.go
+++ b/options.go
@@ -9,7 +9,7 @@ type options struct {
 	sqlslogOptions
 }
 
-func newDefaultOptions(driverName string, formatter StepLogMsgFormatter) *options {
+func newDefaultOptions(driverName string, formatter StepEventMsgBuilder) *options {
 	return &options{
 		stepLoggerOptions: stepLoggerOptions{
 			logger:       slog.Default(),
@@ -27,7 +27,7 @@ var stepLogMsgFormatter = StepLogMsgWithoutEventName
 
 // SetStepLogMsgFormatter sets the formatter for the step name used in logs.
 // If not set, the default is StepLogMsgWithEventName.
-func SetStepLogMsgFormatter(f StepLogMsgFormatter) { stepLogMsgFormatter = f }
+func SetStepLogMsgFormatter(f StepEventMsgBuilder) { stepLogMsgFormatter = f }
 
 func newOptions(driverName string, opts ...Option) *options {
 	o := newDefaultOptions(driverName, stepLogMsgFormatter)

--- a/options.go
+++ b/options.go
@@ -23,7 +23,7 @@ func newDefaultOptions(driverName string, formatter StepEventMsgBuilder) *option
 // Option is a function that sets an option on the options struct.
 type Option func(*options)
 
-var stepLogMsgFormatter = StepLogMsgWithoutEventName
+var stepLogMsgFormatter = StepEventMsgWithoutEventName
 
 // SetStepLogMsgFormatter sets the formatter for the step name used in logs.
 // If not set, the default is StepLogMsgWithEventName.

--- a/options_example_test.go
+++ b/options_example_test.go
@@ -18,8 +18,8 @@ func ExampleLogger() {
 }
 
 func ExampleSetStepLogMsgFormatter() {
-	sqlslog.SetStepLogMsgFormatter(func(name string, event sqlslog.Event) string {
-		return name + "/" + event.String()
+	sqlslog.SetStepLogMsgFormatter(func(step sqlslog.Step, event sqlslog.Event) string {
+		return step.String() + "/" + event.String()
 	})
 	dsn := "file::memory:?cache=shared"
 	ctx := context.TODO()

--- a/options_example_test.go
+++ b/options_example_test.go
@@ -17,8 +17,8 @@ func ExampleLogger() {
 	defer db.Close()
 }
 
-func ExampleSetStepLogMsgFormatter() {
-	sqlslog.SetStepLogMsgFormatter(func(step sqlslog.Step, event sqlslog.Event) string {
+func ExampleSetStepEventMsgBuilder() {
+	sqlslog.SetStepEventMsgBuilder(func(step sqlslog.Step, event sqlslog.Event) string {
 		return step.String() + "/" + event.String()
 	})
 	dsn := "file::memory:?cache=shared"

--- a/options_test.go
+++ b/options_test.go
@@ -14,7 +14,7 @@ func TestSetStepLogMsgFormatter(t *testing.T) {
 
 	t.Run("CustomStepLogMsgFormatter", func(t *testing.T) {
 		t.Parallel()
-		formatter, backup := StepLogMsgWithEventName, stepLogMsgFormatter
+		formatter, backup := StepEventMsgWithEventName, stepLogMsgFormatter
 		SetStepLogMsgFormatter(formatter)
 		defer SetStepLogMsgFormatter(backup)
 		opts := newOptions("dummy")

--- a/options_test.go
+++ b/options_test.go
@@ -2,7 +2,7 @@ package sqlslog
 
 import "testing"
 
-func TestSetStepLogMsgFormatter(t *testing.T) {
+func TestSetStepEventMsgBuilder(t *testing.T) {
 	t.Parallel()
 	t.Run("defaultOptions", func(t *testing.T) {
 		t.Parallel()
@@ -12,11 +12,11 @@ func TestSetStepLogMsgFormatter(t *testing.T) {
 		}
 	})
 
-	t.Run("CustomStepLogMsgFormatter", func(t *testing.T) {
+	t.Run("CustomStepEventMsgBuilder", func(t *testing.T) {
 		t.Parallel()
-		formatter, backup := StepEventMsgWithEventName, stepLogMsgFormatter
-		SetStepLogMsgFormatter(formatter)
-		defer SetStepLogMsgFormatter(backup)
+		builder, backup := StepEventMsgWithEventName, stepEventMsgBuilder
+		SetStepEventMsgBuilder(builder)
+		defer SetStepEventMsgBuilder(backup)
 		opts := newOptions("dummy")
 		if opts.DriverOptions.ConnOptions.Begin.Complete.Msg != "Conn.Begin Complete" {
 			t.Errorf("unexpected default value: %s", opts.DriverOptions.ConnOptions.Begin.Complete.Msg)

--- a/rows.go
+++ b/rows.go
@@ -16,9 +16,9 @@ type rowsOptions struct {
 
 func defaultRowsOptions(formatter StepLogMsgFormatter) *rowsOptions {
 	return &rowsOptions{
-		Close:         *defaultStepOptions(formatter, "Rows.Close", LevelDebug),
-		Next:          *defaultStepOptions(formatter, "Rows.Next", LevelDebug, HandleRowsNextError),
-		NextResultSet: *defaultStepOptions(formatter, "Rows.NextResultSet", LevelDebug),
+		Close:         *defaultStepOptions(formatter, StepRowsClose, LevelDebug),
+		Next:          *defaultStepOptions(formatter, StepRowsNext, LevelDebug, HandleRowsNextError),
+		NextResultSet: *defaultStepOptions(formatter, StepRowsNextResultSet, LevelDebug),
 	}
 }
 

--- a/rows.go
+++ b/rows.go
@@ -14,7 +14,7 @@ type rowsOptions struct {
 	NextResultSet StepOptions
 }
 
-func defaultRowsOptions(formatter StepLogMsgFormatter) *rowsOptions {
+func defaultRowsOptions(formatter StepEventMsgBuilder) *rowsOptions {
 	return &rowsOptions{
 		Close:         *defaultStepOptions(formatter, StepRowsClose, LevelDebug),
 		Next:          *defaultStepOptions(formatter, StepRowsNext, LevelDebug, HandleRowsNextError),

--- a/rows.go
+++ b/rows.go
@@ -14,11 +14,11 @@ type rowsOptions struct {
 	NextResultSet StepOptions
 }
 
-func defaultRowsOptions(formatter StepEventMsgBuilder) *rowsOptions {
+func defaultRowsOptions(msgb StepEventMsgBuilder) *rowsOptions {
 	return &rowsOptions{
-		Close:         *defaultStepOptions(formatter, StepRowsClose, LevelDebug),
-		Next:          *defaultStepOptions(formatter, StepRowsNext, LevelDebug, HandleRowsNextError),
-		NextResultSet: *defaultStepOptions(formatter, StepRowsNextResultSet, LevelDebug),
+		Close:         *defaultStepOptions(msgb, StepRowsClose, LevelDebug),
+		Next:          *defaultStepOptions(msgb, StepRowsNext, LevelDebug, HandleRowsNextError),
+		NextResultSet: *defaultStepOptions(msgb, StepRowsNextResultSet, LevelDebug),
 	}
 }
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -89,7 +89,7 @@ func TestRowsNextResultSet(t *testing.T) {
 	}
 	buf := bytes.NewBuffer(nil)
 	logger := slog.New(NewJSONHandler(buf, nil))
-	rowsOptions := defaultRowsOptions(StepLogMsgWithoutEventName)
+	rowsOptions := defaultRowsOptions(StepEventMsgWithoutEventName)
 	wrapped := wrapRows(rows, newStepLogger(newStepLoggerOptions(logger)), rowsOptions)
 	wrappedRNRS, ok := wrapped.(driver.RowsNextResultSet)
 	if !ok {

--- a/step.go
+++ b/step.go
@@ -1,0 +1,39 @@
+package sqlslog
+
+type Step string
+
+func (s Step) String() string {
+	return string(s)
+}
+
+const (
+	StepConnBegin          Step = "Conn.Begin"
+	StepConnBeginTx        Step = "Conn.BeginTx"
+	StepConnClose          Step = "Conn.Close"
+	StepConnPrepare        Step = "Conn.Prepare"
+	StepConnPrepareContext Step = "Conn.PrepareContext"
+	StepConnResetSession   Step = "Conn.ResetSession"
+	StepConnPing           Step = "Conn.Ping"
+	StepConnExecContext    Step = "Conn.ExecContext"
+	StepConnQueryContext   Step = "Conn.QueryContext"
+
+	StepConnectorConnect Step = "Connector.Connect"
+
+	StepDriverOpen          Step = "Driver.Open"
+	StepDriverOpenConnector Step = "Driver.OpenConnector"
+
+	StepSqlslogOpen Step = "Open"
+
+	StepRowsClose         Step = "Rows.Close"
+	StepRowsNext          Step = "Rows.Next"
+	StepRowsNextResultSet Step = "Rows.NextResultSet"
+
+	StepStmtClose        Step = "Stmt.Close"
+	StepStmtExec         Step = "Stmt.Exec"
+	StepStmtQuery        Step = "Stmt.Query"
+	StepStmtExecContext  Step = "Stmt.ExecContext"
+	StepStmtQueryContext Step = "Stmt.QueryContext"
+
+	StepTxCommit   Step = "Tx.Commit"
+	StepTxRollback Step = "Tx.Rollback"
+)

--- a/step_options.go
+++ b/step_options.go
@@ -7,29 +7,6 @@ type EventOptions struct {
 	Level Level
 }
 
-// Event is the event type of the step.
-type Event int
-
-const (
-	EventStart    Event = iota + 1 // Event when the step starts.
-	EventError                     // Event when the step ends with an error.
-	EventComplete                  // Event when the step completes successfully.
-)
-
-// String returns the string representation of the event.
-func (pe *Event) String() string {
-	switch *pe {
-	case EventStart:
-		return "Start"
-	case EventError:
-		return "Error"
-	case EventComplete:
-		return "Complete"
-	default:
-		return "Unknown"
-	}
-}
-
 type Step string
 
 func (s Step) String() string {

--- a/step_options.go
+++ b/step_options.go
@@ -7,44 +7,6 @@ type EventOptions struct {
 	Level Level
 }
 
-type Step string
-
-func (s Step) String() string {
-	return string(s)
-}
-
-const (
-	StepConnBegin          Step = "Conn.Begin"
-	StepConnBeginTx        Step = "Conn.BeginTx"
-	StepConnClose          Step = "Conn.Close"
-	StepConnPrepare        Step = "Conn.Prepare"
-	StepConnPrepareContext Step = "Conn.PrepareContext"
-	StepConnResetSession   Step = "Conn.ResetSession"
-	StepConnPing           Step = "Conn.Ping"
-	StepConnExecContext    Step = "Conn.ExecContext"
-	StepConnQueryContext   Step = "Conn.QueryContext"
-
-	StepConnectorConnect Step = "Connector.Connect"
-
-	StepDriverOpen          Step = "Driver.Open"
-	StepDriverOpenConnector Step = "Driver.OpenConnector"
-
-	StepSqlslogOpen Step = "Open"
-
-	StepRowsClose         Step = "Rows.Close"
-	StepRowsNext          Step = "Rows.Next"
-	StepRowsNextResultSet Step = "Rows.NextResultSet"
-
-	StepStmtClose        Step = "Stmt.Close"
-	StepStmtExec         Step = "Stmt.Exec"
-	StepStmtQuery        Step = "Stmt.Query"
-	StepStmtExecContext  Step = "Stmt.ExecContext"
-	StepStmtQueryContext Step = "Stmt.QueryContext"
-
-	StepTxCommit   Step = "Tx.Commit"
-	StepTxRollback Step = "Tx.Rollback"
-)
-
 // StepLogMsgFormatter is the function type to format the step log message.
 type StepLogMsgFormatter func(step Step, event Event) string
 

--- a/step_options.go
+++ b/step_options.go
@@ -7,8 +7,8 @@ type EventOptions struct {
 	Level Level
 }
 
-// StepLogMsgFormatter is the function type to format the step log message.
-type StepLogMsgFormatter func(step Step, event Event) string
+// StepEventMsgBuilder is the function type to format the step log message.
+type StepEventMsgBuilder func(step Step, event Event) string
 
 // StepLogMsgWithEventName returns the formatted step log message with the event name.
 func StepLogMsgWithEventName(step Step, event Event) string {
@@ -45,7 +45,7 @@ func (o *StepOptions) compare(other *StepOptions) bool {
 		o.Complete.Level == other.Complete.Level
 }
 
-func newStepOptions(f StepLogMsgFormatter, step Step, startLevel, errorLevel, completeLevel Level) *StepOptions {
+func newStepOptions(f StepEventMsgBuilder, step Step, startLevel, errorLevel, completeLevel Level) *StepOptions {
 	return &StepOptions{
 		Start:    EventOptions{Msg: f(step, EventStart), Level: startLevel},
 		Error:    EventOptions{Msg: f(step, EventError), Level: errorLevel},
@@ -53,7 +53,7 @@ func newStepOptions(f StepLogMsgFormatter, step Step, startLevel, errorLevel, co
 	}
 }
 
-func defaultStepOptions(formatter StepLogMsgFormatter, step Step, completeLevel Level, errHandlers ...func(error) (bool, []slog.Attr)) *StepOptions { // nolint:unparam
+func defaultStepOptions(formatter StepEventMsgBuilder, step Step, completeLevel Level, errHandlers ...func(error) (bool, []slog.Attr)) *StepOptions { // nolint:unparam
 	var startLevel Level
 	switch completeLevel { // nolint:exhaustive
 	case LevelError:

--- a/step_options.go
+++ b/step_options.go
@@ -10,8 +10,8 @@ type EventOptions struct {
 // StepEventMsgBuilder is the function type to format the step log message.
 type StepEventMsgBuilder func(step Step, event Event) string
 
-// StepLogMsgWithEventName returns the formatted step log message with the event name.
-func StepLogMsgWithEventName(step Step, event Event) string {
+// StepEventMsgWithEventName returns the formatted step log message with the event name.
+func StepEventMsgWithEventName(step Step, event Event) string {
 	return step.String() + " " + event.String()
 }
 

--- a/step_options.go
+++ b/step_options.go
@@ -30,17 +30,23 @@ func (pe *Event) String() string {
 	}
 }
 
+type Step string
+
+func (s Step) String() string {
+	return string(s)
+}
+
 // StepLogMsgFormatter is the function type to format the step log message.
-type StepLogMsgFormatter func(name string, event Event) string
+type StepLogMsgFormatter func(step Step, event Event) string
 
 // StepLogMsgWithEventName returns the formatted step log message with the event name.
-func StepLogMsgWithEventName(name string, event Event) string {
-	return name + " " + event.String()
+func StepLogMsgWithEventName(step Step, event Event) string {
+	return step.String() + " " + event.String()
 }
 
 // StepLogMsgWithoutEventName returns the formatted step log message without the event name.
-func StepLogMsgWithoutEventName(name string, _ Event) string {
-	return name
+func StepLogMsgWithoutEventName(step Step, _ Event) string {
+	return step.String()
 }
 
 // StepOptions is an struct that expresses the options for the step.
@@ -68,15 +74,15 @@ func (o *StepOptions) compare(other *StepOptions) bool {
 		o.Complete.Level == other.Complete.Level
 }
 
-func newStepOptions(f StepLogMsgFormatter, name string, startLevel, errorLevel, completeLevel Level) *StepOptions {
+func newStepOptions(f StepLogMsgFormatter, step Step, startLevel, errorLevel, completeLevel Level) *StepOptions {
 	return &StepOptions{
-		Start:    EventOptions{Msg: f(name, EventStart), Level: startLevel},
-		Error:    EventOptions{Msg: f(name, EventError), Level: errorLevel},
-		Complete: EventOptions{Msg: f(name, EventComplete), Level: completeLevel},
+		Start:    EventOptions{Msg: f(step, EventStart), Level: startLevel},
+		Error:    EventOptions{Msg: f(step, EventError), Level: errorLevel},
+		Complete: EventOptions{Msg: f(step, EventComplete), Level: completeLevel},
 	}
 }
 
-func defaultStepOptions(formatter StepLogMsgFormatter, name string, completeLevel Level, errHandlers ...func(error) (bool, []slog.Attr)) *StepOptions { // nolint:unparam
+func defaultStepOptions(formatter StepLogMsgFormatter, step Step, completeLevel Level, errHandlers ...func(error) (bool, []slog.Attr)) *StepOptions { // nolint:unparam
 	var startLevel Level
 	switch completeLevel { // nolint:exhaustive
 	case LevelError:
@@ -88,7 +94,7 @@ func defaultStepOptions(formatter StepLogMsgFormatter, name string, completeLeve
 	default:
 		startLevel = LevelVerbose
 	}
-	r := newStepOptions(formatter, name, startLevel, LevelError, completeLevel)
+	r := newStepOptions(formatter, step, startLevel, LevelError, completeLevel)
 	if len(errHandlers) > 0 {
 		r.ErrorHandler = errHandlers[0]
 	}

--- a/step_options.go
+++ b/step_options.go
@@ -53,7 +53,7 @@ func newStepOptions(f StepEventMsgBuilder, step Step, startLevel, errorLevel, co
 	}
 }
 
-func defaultStepOptions(formatter StepEventMsgBuilder, step Step, completeLevel Level, errHandlers ...func(error) (bool, []slog.Attr)) *StepOptions { // nolint:unparam
+func defaultStepOptions(msgb StepEventMsgBuilder, step Step, completeLevel Level, errHandlers ...func(error) (bool, []slog.Attr)) *StepOptions { // nolint:unparam
 	var startLevel Level
 	switch completeLevel { // nolint:exhaustive
 	case LevelError:
@@ -65,7 +65,7 @@ func defaultStepOptions(formatter StepEventMsgBuilder, step Step, completeLevel 
 	default:
 		startLevel = LevelVerbose
 	}
-	r := newStepOptions(formatter, step, startLevel, LevelError, completeLevel)
+	r := newStepOptions(msgb, step, startLevel, LevelError, completeLevel)
 	if len(errHandlers) > 0 {
 		r.ErrorHandler = errHandlers[0]
 	}

--- a/step_options.go
+++ b/step_options.go
@@ -15,8 +15,8 @@ func StepEventMsgWithEventName(step Step, event Event) string {
 	return step.String() + " " + event.String()
 }
 
-// StepLogMsgWithoutEventName returns the formatted step log message without the event name.
-func StepLogMsgWithoutEventName(step Step, _ Event) string {
+// StepEventMsgWithoutEventName returns the formatted step log message without the event name.
+func StepEventMsgWithoutEventName(step Step, _ Event) string {
 	return step.String()
 }
 

--- a/step_options.go
+++ b/step_options.go
@@ -36,6 +36,38 @@ func (s Step) String() string {
 	return string(s)
 }
 
+const (
+	StepConnBegin          Step = "Conn.Begin"
+	StepConnBeginTx        Step = "Conn.BeginTx"
+	StepConnClose          Step = "Conn.Close"
+	StepConnPrepare        Step = "Conn.Prepare"
+	StepConnPrepareContext Step = "Conn.PrepareContext"
+	StepConnResetSession   Step = "Conn.ResetSession"
+	StepConnPing           Step = "Conn.Ping"
+	StepConnExecContext    Step = "Conn.ExecContext"
+	StepConnQueryContext   Step = "Conn.QueryContext"
+
+	StepConnectorConnect Step = "Connector.Connect"
+
+	StepDriverOpen          Step = "Driver.Open"
+	StepDriverOpenConnector Step = "Driver.OpenConnector"
+
+	StepSqlslogOpen Step = "Open"
+
+	StepRowsClose         Step = "Rows.Close"
+	StepRowsNext          Step = "Rows.Next"
+	StepRowsNextResultSet Step = "Rows.NextResultSet"
+
+	StepStmtClose        Step = "Stmt.Close"
+	StepStmtExec         Step = "Stmt.Exec"
+	StepStmtQuery        Step = "Stmt.Query"
+	StepStmtExecContext  Step = "Stmt.ExecContext"
+	StepStmtQueryContext Step = "Stmt.QueryContext"
+
+	StepTxCommit   Step = "Tx.Commit"
+	StepTxRollback Step = "Tx.Rollback"
+)
+
 // StepLogMsgFormatter is the function type to format the step log message.
 type StepLogMsgFormatter func(step Step, event Event) string
 

--- a/step_options_test.go
+++ b/step_options_test.go
@@ -68,7 +68,7 @@ func TestDefaultStepOptions(t *testing.T) {
 	t.Parallel()
 	t.Run("LevelError", func(t *testing.T) {
 		t.Parallel()
-		o := defaultStepOptions(StepLogMsgWithoutEventName, Step("test"), LevelError)
+		o := defaultStepOptions(StepEventMsgWithoutEventName, Step("test"), LevelError)
 		if o.Start.Level != LevelInfo {
 			t.Errorf("Expected %v, but got %v", LevelInfo, o.Start.Level)
 		}

--- a/step_options_test.go
+++ b/step_options_test.go
@@ -106,7 +106,7 @@ func TestDefaultStepOptions(t *testing.T) {
 	t.Parallel()
 	t.Run("LevelError", func(t *testing.T) {
 		t.Parallel()
-		o := defaultStepOptions(StepLogMsgWithoutEventName, "test", LevelError)
+		o := defaultStepOptions(StepLogMsgWithoutEventName, Step("test"), LevelError)
 		if o.Start.Level != LevelInfo {
 			t.Errorf("Expected %v, but got %v", LevelInfo, o.Start.Level)
 		}

--- a/step_options_test.go
+++ b/step_options_test.go
@@ -2,44 +2,6 @@ package sqlslog
 
 import "testing"
 
-func TestEventString(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name string
-		e    Event
-		want string
-	}{
-		{
-			name: "EventStart",
-			e:    EventStart,
-			want: "Start",
-		},
-		{
-			name: "EventError",
-			e:    EventError,
-			want: "Error",
-		},
-		{
-			name: "EventComplete",
-			e:    EventComplete,
-			want: "Complete",
-		},
-		{
-			name: "Unknown",
-			e:    Event(0),
-			want: "Unknown",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			if got := tt.e.String(); got != tt.want {
-				t.Errorf("Event.String() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestStepOptionsSetLevel(t *testing.T) {
 	t.Parallel()
 

--- a/stmt.go
+++ b/stmt.go
@@ -19,11 +19,11 @@ type stmtOptions struct {
 
 func defaultStmtOptions(formatter StepLogMsgFormatter) *stmtOptions {
 	return &stmtOptions{
-		Close:        *defaultStepOptions(formatter, "Stmt.Close", LevelInfo),
-		Exec:         *defaultStepOptions(formatter, "Stmt.Exec", LevelInfo),
-		Query:        *defaultStepOptions(formatter, "Stmt.Query", LevelInfo),
-		ExecContext:  *defaultStepOptions(formatter, "Stmt.ExecContext", LevelInfo),
-		QueryContext: *defaultStepOptions(formatter, "Stmt.QueryContext", LevelInfo),
+		Close:        *defaultStepOptions(formatter, StepStmtClose, LevelInfo),
+		Exec:         *defaultStepOptions(formatter, StepStmtExec, LevelInfo),
+		Query:        *defaultStepOptions(formatter, StepStmtQuery, LevelInfo),
+		ExecContext:  *defaultStepOptions(formatter, StepStmtExecContext, LevelInfo),
+		QueryContext: *defaultStepOptions(formatter, StepStmtQueryContext, LevelInfo),
 		Rows:         defaultRowsOptions(formatter),
 	}
 }

--- a/stmt.go
+++ b/stmt.go
@@ -17,14 +17,14 @@ type stmtOptions struct {
 	Rows *rowsOptions
 }
 
-func defaultStmtOptions(formatter StepEventMsgBuilder) *stmtOptions {
+func defaultStmtOptions(msgb StepEventMsgBuilder) *stmtOptions {
 	return &stmtOptions{
-		Close:        *defaultStepOptions(formatter, StepStmtClose, LevelInfo),
-		Exec:         *defaultStepOptions(formatter, StepStmtExec, LevelInfo),
-		Query:        *defaultStepOptions(formatter, StepStmtQuery, LevelInfo),
-		ExecContext:  *defaultStepOptions(formatter, StepStmtExecContext, LevelInfo),
-		QueryContext: *defaultStepOptions(formatter, StepStmtQueryContext, LevelInfo),
-		Rows:         defaultRowsOptions(formatter),
+		Close:        *defaultStepOptions(msgb, StepStmtClose, LevelInfo),
+		Exec:         *defaultStepOptions(msgb, StepStmtExec, LevelInfo),
+		Query:        *defaultStepOptions(msgb, StepStmtQuery, LevelInfo),
+		ExecContext:  *defaultStepOptions(msgb, StepStmtExecContext, LevelInfo),
+		QueryContext: *defaultStepOptions(msgb, StepStmtQueryContext, LevelInfo),
+		Rows:         defaultRowsOptions(msgb),
 	}
 }
 

--- a/stmt.go
+++ b/stmt.go
@@ -17,7 +17,7 @@ type stmtOptions struct {
 	Rows *rowsOptions
 }
 
-func defaultStmtOptions(formatter StepLogMsgFormatter) *stmtOptions {
+func defaultStmtOptions(formatter StepEventMsgBuilder) *stmtOptions {
 	return &stmtOptions{
 		Close:        *defaultStepOptions(formatter, StepStmtClose, LevelInfo),
 		Exec:         *defaultStepOptions(formatter, StepStmtExec, LevelInfo),

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -47,7 +47,7 @@ func TestWrapStmt(t *testing.T) {
 		t.Parallel()
 		mock := &mockStmtForWrapStmt{}
 		logger := &stepLogger{}
-		stmt := wrapStmt(mock, logger, defaultStmtOptions(StepLogMsgWithoutEventName))
+		stmt := wrapStmt(mock, logger, defaultStmtOptions(StepEventMsgWithoutEventName))
 		if stmt == nil {
 			t.Fatal("Expected non-nil")
 		}
@@ -62,7 +62,7 @@ func TestWrapStmt(t *testing.T) {
 
 		buf := bytes.NewBuffer(nil)
 		logger := slog.New(NewJSONHandler(buf, nil))
-		wrapped := wrapStmt(mock, newStepLogger(newStepLoggerOptions(logger)), defaultStmtOptions(StepLogMsgWithoutEventName))
+		wrapped := wrapStmt(mock, newStepLogger(newStepLoggerOptions(logger)), defaultStmtOptions(StepEventMsgWithoutEventName))
 		_, err := wrapped.Query(nil) // nolint:staticcheck
 		if err == nil {
 			t.Fatal("Expected non-nil")
@@ -102,7 +102,7 @@ func TestWithMockErrorStmtWithContext(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 	logger := slog.New(NewJSONHandler(buf, nil))
-	wrapped := wrapStmt(mock, newStepLogger(newStepLoggerOptions(logger)), defaultStmtOptions(StepLogMsgWithoutEventName))
+	wrapped := wrapStmt(mock, newStepLogger(newStepLoggerOptions(logger)), defaultStmtOptions(StepEventMsgWithoutEventName))
 	stmtWithQueryContext, ok := wrapped.(driver.StmtQueryContext)
 	if !ok {
 		t.Fatal("Expected StmtQueryContext")

--- a/tx.go
+++ b/tx.go
@@ -9,10 +9,10 @@ type txOptions struct {
 	Rollback StepOptions
 }
 
-func defaultTxOptions(formatter StepEventMsgBuilder) *txOptions {
+func defaultTxOptions(msgb StepEventMsgBuilder) *txOptions {
 	return &txOptions{
-		Commit:   *defaultStepOptions(formatter, StepTxCommit, LevelInfo),
-		Rollback: *defaultStepOptions(formatter, StepTxRollback, LevelInfo),
+		Commit:   *defaultStepOptions(msgb, StepTxCommit, LevelInfo),
+		Rollback: *defaultStepOptions(msgb, StepTxRollback, LevelInfo),
 	}
 }
 

--- a/tx.go
+++ b/tx.go
@@ -9,7 +9,7 @@ type txOptions struct {
 	Rollback StepOptions
 }
 
-func defaultTxOptions(formatter StepLogMsgFormatter) *txOptions {
+func defaultTxOptions(formatter StepEventMsgBuilder) *txOptions {
 	return &txOptions{
 		Commit:   *defaultStepOptions(formatter, StepTxCommit, LevelInfo),
 		Rollback: *defaultStepOptions(formatter, StepTxRollback, LevelInfo),

--- a/tx.go
+++ b/tx.go
@@ -11,8 +11,8 @@ type txOptions struct {
 
 func defaultTxOptions(formatter StepLogMsgFormatter) *txOptions {
 	return &txOptions{
-		Commit:   *defaultStepOptions(formatter, "Tx.Commit", LevelInfo),
-		Rollback: *defaultStepOptions(formatter, "Tx.Rollback", LevelInfo),
+		Commit:   *defaultStepOptions(formatter, StepTxCommit, LevelInfo),
+		Rollback: *defaultStepOptions(formatter, StepTxRollback, LevelInfo),
 	}
 }
 


### PR DESCRIPTION
- Define `Step` type to list up the items as code
- Rename StepLogMsgFormatter to StepEventMsgBuilder