### PR TITLE
Work with sqlslog log level unless user creates a slog.Handler by using sqlslog.New(JSON|Text)Handler

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -116,6 +116,7 @@ issues:
     - path: _test\.go
       linters:
         - err113
+        - forcetypeassert
         - funlen
 linters-settings:
   cyclop:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,7 +91,7 @@ linters:
     - stylecheck
     - tagalign
     - tagliatelle
-    - tenv
+    # - tenv # The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature another linter. Replaced by usetesting.
     # - testableexamples
     - testifylint
     # - testpackage
@@ -101,6 +101,7 @@ linters:
     - unparam
     - unused
     - usestdlibvars
+    - usetesting
     # - varnamelen
     - wastedassign
     - whitespace

--- a/conn_test.go
+++ b/conn_test.go
@@ -142,7 +142,7 @@ var (
 
 func TestWithMockErrorConn(t *testing.T) {
 	t.Parallel()
-	logger := newStepLogger(slog.Default(), nil)
+	logger := newStepLogger(slog.Default(), defaultStepLoggerOptions())
 	connOptions := defaultConnOptions("sqlite3", StepEventMsgWithoutEventName)
 	w := wrapConn(newMockErrConn(errors.New("unexpected error")), logger, connOptions)
 	t.Run("Begin", func(t *testing.T) {
@@ -173,7 +173,7 @@ func TestWithMockErrorConn(t *testing.T) {
 
 func TestPingInCase(t *testing.T) {
 	t.Parallel()
-	logger := newStepLogger(slog.Default(), nil)
+	logger := newStepLogger(slog.Default(), defaultStepLoggerOptions())
 	conn := newMockErrConn(nil)
 	w := &connWithContextWrapper{
 		connWrapper: connWrapper{

--- a/conn_test.go
+++ b/conn_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
+	"log/slog"
 	"testing"
 )
 
@@ -141,7 +142,7 @@ var (
 
 func TestWithMockErrorConn(t *testing.T) {
 	t.Parallel()
-	logger := newStepLogger(nil)
+	logger := newStepLogger(slog.Default(), nil)
 	connOptions := defaultConnOptions("sqlite3", StepEventMsgWithoutEventName)
 	w := wrapConn(newMockErrConn(errors.New("unexpected error")), logger, connOptions)
 	t.Run("Begin", func(t *testing.T) {
@@ -172,7 +173,7 @@ func TestWithMockErrorConn(t *testing.T) {
 
 func TestPingInCase(t *testing.T) {
 	t.Parallel()
-	logger := newStepLogger(nil)
+	logger := newStepLogger(slog.Default(), nil)
 	conn := newMockErrConn(nil)
 	w := &connWithContextWrapper{
 		connWrapper: connWrapper{

--- a/doc.go
+++ b/doc.go
@@ -4,22 +4,21 @@ sqlslog uses [*slog.Logger] to log SQL database driver operations.
 
 # How to use
 
-	ctx := context.TODO() // or a context.Context
-	db, err := sqlslog.Open(ctx, "mysql", dsn)
+	db, logger, err := sqlslog.Open(ctx, "mysql", dsn)
 
 You can also use options to customize the logger's behavior.
 
 [Open] takes [Option] s to customize the logging behavior.
-[Option] is created by using functions like [Logger], [ConnPrepareContext], [StmtQueryContext], etc.
+[Option] is created by using functions like [HandlerFunc], [ConnPrepareContext], [StmtQueryContext], etc.
 
-# Logger
+# HandlerFunc / Handler
 
-[Logger] sets the slog.Logger to be used. If not set, the default is slog.Default().
+[HandlerFunc] sets the function to create a [slog.Handler] for the logger.
+slogslog provides [NewTextHandler] and [NewJSONHandler] to create a [slog.Handler] for sqlslog.
 
-The logger from slog.Default() does not have options for the log levels [LevelTrace] and [LevelVerbose].
-
-You can create a [slog.Handler] by using [sqlslog.NewTextHandler] or [sqlslog.NewJSONHandler] customized for sqlslog [Level].
-See examples for [NewTextHandler] and [NewJSONHandler] for more details.
+You can also use your own [slog.Handler] by using [Handler] with your [slog.Handler].
+But your own [slog.Handler] should know how to log [LevelTrace] and [LevelVerbose] log levels.
+So you should use [sqlslog.ReplaceLevelAttr] with your [slog.Handler].
 
 # Level
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -33,7 +33,7 @@ func TestDriverContextWrapperOpenConnector(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		logger := slog.New(NewTextHandler(buf, nil))
 		dw := wrapDriver(&mockErrorDiverContext{},
-			newStepLogger(newStepLoggerOptions(logger)),
+			newStepLogger(logger, newStepLoggerOptions()),
 			defaultDriverOptions("sqlite3", StepEventMsgWithoutEventName),
 		)
 		dwc, ok := dw.(driver.DriverContext)

--- a/driver_test.go
+++ b/driver_test.go
@@ -33,7 +33,7 @@ func TestDriverContextWrapperOpenConnector(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		logger := slog.New(NewTextHandler(buf, nil))
 		dw := wrapDriver(&mockErrorDiverContext{},
-			newStepLogger(logger, newStepLoggerOptions()),
+			newStepLogger(logger, defaultStepLoggerOptions()),
 			defaultDriverOptions("sqlite3", StepEventMsgWithoutEventName),
 		)
 		dwc, ok := dw.(driver.DriverContext)

--- a/examples/logs-mysql/results/debug-log.txt
+++ b/examples/logs-mysql/results/debug-log.txt
@@ -1,66 +1,65 @@
-go run . debug text
-time=2025-02-19T08:00:11.509+09:00 level=DEBUG msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1
-time=2025-02-19T08:00:11.510+09:00 level=DEBUG msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1
-time=2025-02-19T08:00:11.510+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=3333 conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:11.510+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=185291
-time=2025-02-19T08:00:11.510+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:11.510+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:11.513+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=2852042 error="driver: bad connection"
-time=2025-02-19T08:00:11.513+09:00 level=ERROR msg=Connector.Connect duration=2934334 error="driver: bad connection"
-time=2025-02-19T08:00:11.513+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:11.513+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:11.514+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=722541 error="driver: bad connection"
-time=2025-02-19T08:00:11.514+09:00 level=ERROR msg=Connector.Connect duration=779958 error="driver: bad connection"
-time=2025-02-19T08:00:11.514+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:11.514+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:11.514+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=506791 error="driver: bad connection"
-time=2025-02-19T08:00:11.514+09:00 level=ERROR msg=Connector.Connect duration=535875 error="driver: bad connection"
-time=2025-02-19T08:00:13.515+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:13.515+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:13.518+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=2542416 error="driver: bad connection"
-time=2025-02-19T08:00:13.518+09:00 level=ERROR msg=Connector.Connect duration=2574000 error="driver: bad connection"
-time=2025-02-19T08:00:13.518+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:13.518+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:13.519+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=891583 error="driver: bad connection"
-time=2025-02-19T08:00:13.519+09:00 level=ERROR msg=Connector.Connect duration=907958 error="driver: bad connection"
-time=2025-02-19T08:00:13.519+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:13.519+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:13.520+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=718791 error="driver: bad connection"
-time=2025-02-19T08:00:13.520+09:00 level=ERROR msg=Connector.Connect duration=731958 error="driver: bad connection"
-time=2025-02-19T08:00:15.521+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:15.521+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:15.523+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=2072375 error="driver: bad connection"
-time=2025-02-19T08:00:15.523+09:00 level=ERROR msg=Connector.Connect duration=2203833 error="driver: bad connection"
-time=2025-02-19T08:00:15.523+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:15.523+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:15.524+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=650042 error="driver: bad connection"
-time=2025-02-19T08:00:15.524+09:00 level=ERROR msg=Connector.Connect duration=704625 error="driver: bad connection"
-time=2025-02-19T08:00:15.524+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:15.524+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:15.524+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=581417 error="driver: bad connection"
-time=2025-02-19T08:00:15.524+09:00 level=ERROR msg=Connector.Connect duration=627750 error="driver: bad connection"
-time=2025-02-19T08:00:17.526+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:17.526+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:17.531+09:00 level=INFO msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=5497500
-time=2025-02-19T08:00:17.531+09:00 level=INFO msg=Connector.Connect duration=5671708
-time=2025-02-19T08:00:17.532+09:00 level=DEBUG msg=Conn.ExecContext conn_id=4wu72jGCoqbIjAb6 query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-19T08:00:17.551+09:00 level=INFO msg=Conn.ExecContext conn_id=4wu72jGCoqbIjAb6 query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=19095459
-time=2025-02-19T08:00:17.552+09:00 level=DEBUG msg=Conn.BeginTx conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:17.553+09:00 level=INFO msg=Conn.BeginTx conn_id=4wu72jGCoqbIjAb6 duration=588292 tx_id=MDgM3Y429sgIDDJw
-time=2025-02-19T08:00:17.553+09:00 level=DEBUG msg=Conn.ExecContext conn_id=4wu72jGCoqbIjAb6 query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-19T08:00:17.553+09:00 level=INFO msg=Conn.ExecContext conn_id=4wu72jGCoqbIjAb6 query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1625 skip=true
-time=2025-02-19T08:00:17.553+09:00 level=DEBUG msg=Conn.PrepareContext conn_id=4wu72jGCoqbIjAb6 query="INSERT INTO test1 (id, name) VALUES (?, ?)"
-time=2025-02-19T08:00:17.557+09:00 level=INFO msg=Conn.PrepareContext conn_id=4wu72jGCoqbIjAb6 query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=4153875 stmt_id=u0A18CtK4S31a60Y
-time=2025-02-19T08:00:17.557+09:00 level=DEBUG msg=Stmt.ExecContext conn_id=4wu72jGCoqbIjAb6 stmt_id=u0A18CtK4S31a60Y args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-19T08:00:17.558+09:00 level=INFO msg=Stmt.ExecContext conn_id=4wu72jGCoqbIjAb6 stmt_id=u0A18CtK4S31a60Y args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=569458
-time=2025-02-19T08:00:17.558+09:00 level=DEBUG msg=Stmt.Close conn_id=4wu72jGCoqbIjAb6 stmt_id=u0A18CtK4S31a60Y
-time=2025-02-19T08:00:17.558+09:00 level=INFO msg=Stmt.Close conn_id=4wu72jGCoqbIjAb6 stmt_id=u0A18CtK4S31a60Y duration=10458
-time=2025-02-19T08:00:17.558+09:00 level=DEBUG msg=Tx.Commit conn_id=4wu72jGCoqbIjAb6 tx_id=MDgM3Y429sgIDDJw
-time=2025-02-19T08:00:17.560+09:00 level=INFO msg=Tx.Commit conn_id=4wu72jGCoqbIjAb6 tx_id=MDgM3Y429sgIDDJw duration=1713000
-time=2025-02-19T08:00:17.560+09:00 level=DEBUG msg=Conn.QueryContext conn_id=4wu72jGCoqbIjAb6 query="SELECT * FROM test1" args=[] duration=505917
-time=2025-02-19T08:00:17.560+09:00 level=DEBUG msg=Rows.Next conn_id=4wu72jGCoqbIjAb6 duration=52500 eof=false
-time=2025-02-19T08:00:17.561+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-19T08:00:17.561+09:00 level=DEBUG msg=Rows.Next conn_id=4wu72jGCoqbIjAb6 duration=208 eof=true
-time=2025-02-19T08:00:17.561+09:00 level=DEBUG msg=Rows.Close conn_id=4wu72jGCoqbIjAb6 duration=625
-time=2025-02-19T08:00:17.561+09:00 level=DEBUG msg=Conn.Close conn_id=4wu72jGCoqbIjAb6
-time=2025-02-19T08:00:17.561+09:00 level=INFO msg=Conn.Close conn_id=4wu72jGCoqbIjAb6 duration=33083
+time=2025-02-19T08:24:59.722+09:00 level=DEBUG msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1
+time=2025-02-19T08:24:59.722+09:00 level=DEBUG msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1
+time=2025-02-19T08:24:59.722+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=3208 conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:24:59.722+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=225000
+time=2025-02-19T08:24:59.722+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:24:59.722+09:00 level=DEBUG msg=Connector.Connect conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:24:59.725+09:00 level=ERROR msg=Connector.Connect conn_id=GcehcYURvlj4lPDG duration=2847375 error="driver: bad connection"
+time=2025-02-19T08:24:59.725+09:00 level=ERROR msg=Connector.Connect duration=2927833 error="driver: bad connection"
+time=2025-02-19T08:24:59.725+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:24:59.725+09:00 level=DEBUG msg=Connector.Connect conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:24:59.726+09:00 level=ERROR msg=Connector.Connect conn_id=GcehcYURvlj4lPDG duration=977416 error="driver: bad connection"
+time=2025-02-19T08:24:59.726+09:00 level=ERROR msg=Connector.Connect duration=1028333 error="driver: bad connection"
+time=2025-02-19T08:24:59.726+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:24:59.726+09:00 level=DEBUG msg=Connector.Connect conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:24:59.730+09:00 level=ERROR msg=Connector.Connect conn_id=GcehcYURvlj4lPDG duration=3485500 error="driver: bad connection"
+time=2025-02-19T08:24:59.730+09:00 level=ERROR msg=Connector.Connect duration=3563666 error="driver: bad connection"
+time=2025-02-19T08:25:01.731+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:01.731+09:00 level=DEBUG msg=Connector.Connect conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:25:01.735+09:00 level=ERROR msg=Connector.Connect conn_id=GcehcYURvlj4lPDG duration=3532208 error="driver: bad connection"
+time=2025-02-19T08:25:01.735+09:00 level=ERROR msg=Connector.Connect duration=3716958 error="driver: bad connection"
+time=2025-02-19T08:25:01.735+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:01.735+09:00 level=DEBUG msg=Connector.Connect conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:25:01.738+09:00 level=ERROR msg=Connector.Connect conn_id=GcehcYURvlj4lPDG duration=3166875 error="driver: bad connection"
+time=2025-02-19T08:25:01.738+09:00 level=ERROR msg=Connector.Connect duration=3307167 error="driver: bad connection"
+time=2025-02-19T08:25:01.738+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:01.738+09:00 level=DEBUG msg=Connector.Connect conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:25:01.742+09:00 level=ERROR msg=Connector.Connect conn_id=GcehcYURvlj4lPDG duration=3507917 error="driver: bad connection"
+time=2025-02-19T08:25:01.742+09:00 level=ERROR msg=Connector.Connect duration=3641417 error="driver: bad connection"
+time=2025-02-19T08:25:03.743+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:03.743+09:00 level=DEBUG msg=Connector.Connect conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:25:03.747+09:00 level=ERROR msg=Connector.Connect conn_id=GcehcYURvlj4lPDG duration=3340041 error="driver: bad connection"
+time=2025-02-19T08:25:03.747+09:00 level=ERROR msg=Connector.Connect duration=3583292 error="driver: bad connection"
+time=2025-02-19T08:25:03.747+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:03.747+09:00 level=DEBUG msg=Connector.Connect conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:25:03.750+09:00 level=ERROR msg=Connector.Connect conn_id=GcehcYURvlj4lPDG duration=2590291 error="driver: bad connection"
+time=2025-02-19T08:25:03.750+09:00 level=ERROR msg=Connector.Connect duration=2747792 error="driver: bad connection"
+time=2025-02-19T08:25:03.750+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:03.750+09:00 level=DEBUG msg=Connector.Connect conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:25:03.752+09:00 level=ERROR msg=Connector.Connect conn_id=GcehcYURvlj4lPDG duration=1661208 error="driver: bad connection"
+time=2025-02-19T08:25:03.752+09:00 level=ERROR msg=Connector.Connect duration=1868625 error="driver: bad connection"
+time=2025-02-19T08:25:05.753+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:05.753+09:00 level=DEBUG msg=Connector.Connect conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:25:05.757+09:00 level=INFO msg=Connector.Connect conn_id=GcehcYURvlj4lPDG duration=4553417
+time=2025-02-19T08:25:05.757+09:00 level=INFO msg=Connector.Connect duration=4614041
+time=2025-02-19T08:25:05.758+09:00 level=DEBUG msg=Conn.ExecContext conn_id=GcehcYURvlj4lPDG query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:25:05.774+09:00 level=INFO msg=Conn.ExecContext conn_id=GcehcYURvlj4lPDG query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=15872083
+time=2025-02-19T08:25:05.774+09:00 level=DEBUG msg=Conn.BeginTx conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:25:05.774+09:00 level=INFO msg=Conn.BeginTx conn_id=GcehcYURvlj4lPDG duration=311917 tx_id=P_5GU9YZ66Q7cVCQ
+time=2025-02-19T08:25:05.774+09:00 level=DEBUG msg=Conn.ExecContext conn_id=GcehcYURvlj4lPDG query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:25:05.775+09:00 level=INFO msg=Conn.ExecContext conn_id=GcehcYURvlj4lPDG query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=375 skip=true
+time=2025-02-19T08:25:05.775+09:00 level=DEBUG msg=Conn.PrepareContext conn_id=GcehcYURvlj4lPDG query="INSERT INTO test1 (id, name) VALUES (?, ?)"
+time=2025-02-19T08:25:05.776+09:00 level=INFO msg=Conn.PrepareContext conn_id=GcehcYURvlj4lPDG query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=1626541 stmt_id=nAPIE1kqEGIjsNpe
+time=2025-02-19T08:25:05.776+09:00 level=DEBUG msg=Stmt.ExecContext conn_id=GcehcYURvlj4lPDG stmt_id=nAPIE1kqEGIjsNpe args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:25:05.777+09:00 level=INFO msg=Stmt.ExecContext conn_id=GcehcYURvlj4lPDG stmt_id=nAPIE1kqEGIjsNpe args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=349958
+time=2025-02-19T08:25:05.777+09:00 level=DEBUG msg=Stmt.Close conn_id=GcehcYURvlj4lPDG stmt_id=nAPIE1kqEGIjsNpe
+time=2025-02-19T08:25:05.777+09:00 level=INFO msg=Stmt.Close conn_id=GcehcYURvlj4lPDG stmt_id=nAPIE1kqEGIjsNpe duration=4625
+time=2025-02-19T08:25:05.777+09:00 level=DEBUG msg=Tx.Commit conn_id=GcehcYURvlj4lPDG tx_id=P_5GU9YZ66Q7cVCQ
+time=2025-02-19T08:25:05.779+09:00 level=INFO msg=Tx.Commit conn_id=GcehcYURvlj4lPDG tx_id=P_5GU9YZ66Q7cVCQ duration=2369584
+time=2025-02-19T08:25:05.779+09:00 level=DEBUG msg=Conn.QueryContext conn_id=GcehcYURvlj4lPDG query="SELECT * FROM test1" args=[] duration=348542
+time=2025-02-19T08:25:05.779+09:00 level=DEBUG msg=Rows.Next conn_id=GcehcYURvlj4lPDG duration=13333 eof=false
+time=2025-02-19T08:25:05.779+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:25:05.779+09:00 level=DEBUG msg=Rows.Next conn_id=GcehcYURvlj4lPDG duration=83 eof=true
+time=2025-02-19T08:25:05.779+09:00 level=DEBUG msg=Rows.Close conn_id=GcehcYURvlj4lPDG duration=125
+time=2025-02-19T08:25:05.779+09:00 level=DEBUG msg=Conn.Close conn_id=GcehcYURvlj4lPDG
+time=2025-02-19T08:25:05.779+09:00 level=INFO msg=Conn.Close conn_id=GcehcYURvlj4lPDG duration=18083

--- a/examples/logs-mysql/results/debug-log.txt
+++ b/examples/logs-mysql/results/debug-log.txt
@@ -1,66 +1,66 @@
 go run . debug text
-time=2025-02-06T22:15:46.397+09:00 level=DEBUG msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1
-time=2025-02-06T22:15:46.397+09:00 level=DEBUG msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1
-time=2025-02-06T22:15:46.397+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=3125 conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:46.397+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=155459
-time=2025-02-06T22:15:46.397+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:46.397+09:00 level=DEBUG msg=Connector.Connect conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:46.400+09:00 level=ERROR msg=Connector.Connect conn_id=gwFomUACWTjd26ZR duration=2732667 error="driver: bad connection"
-time=2025-02-06T22:15:46.400+09:00 level=ERROR msg=Connector.Connect duration=2796042 error="driver: bad connection"
-time=2025-02-06T22:15:46.400+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:46.400+09:00 level=DEBUG msg=Connector.Connect conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:46.400+09:00 level=ERROR msg=Connector.Connect conn_id=gwFomUACWTjd26ZR duration=594250 error="driver: bad connection"
-time=2025-02-06T22:15:46.401+09:00 level=ERROR msg=Connector.Connect duration=622083 error="driver: bad connection"
-time=2025-02-06T22:15:46.401+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:46.401+09:00 level=DEBUG msg=Connector.Connect conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:46.401+09:00 level=ERROR msg=Connector.Connect conn_id=gwFomUACWTjd26ZR duration=476333 error="driver: bad connection"
-time=2025-02-06T22:15:46.401+09:00 level=ERROR msg=Connector.Connect duration=508333 error="driver: bad connection"
-time=2025-02-06T22:15:48.402+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:48.402+09:00 level=DEBUG msg=Connector.Connect conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:48.404+09:00 level=ERROR msg=Connector.Connect conn_id=gwFomUACWTjd26ZR duration=1707458 error="driver: bad connection"
-time=2025-02-06T22:15:48.404+09:00 level=ERROR msg=Connector.Connect duration=1798791 error="driver: bad connection"
-time=2025-02-06T22:15:48.404+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:48.404+09:00 level=DEBUG msg=Connector.Connect conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:48.405+09:00 level=ERROR msg=Connector.Connect conn_id=gwFomUACWTjd26ZR duration=1246917 error="driver: bad connection"
-time=2025-02-06T22:15:48.405+09:00 level=ERROR msg=Connector.Connect duration=1337042 error="driver: bad connection"
-time=2025-02-06T22:15:48.405+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:48.405+09:00 level=DEBUG msg=Connector.Connect conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:48.406+09:00 level=ERROR msg=Connector.Connect conn_id=gwFomUACWTjd26ZR duration=1107209 error="driver: bad connection"
-time=2025-02-06T22:15:48.406+09:00 level=ERROR msg=Connector.Connect duration=1169125 error="driver: bad connection"
-time=2025-02-06T22:15:50.407+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:50.407+09:00 level=DEBUG msg=Connector.Connect conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:50.408+09:00 level=ERROR msg=Connector.Connect conn_id=gwFomUACWTjd26ZR duration=1087917 error="driver: bad connection"
-time=2025-02-06T22:15:50.408+09:00 level=ERROR msg=Connector.Connect duration=1152375 error="driver: bad connection"
-time=2025-02-06T22:15:50.408+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:50.408+09:00 level=DEBUG msg=Connector.Connect conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:50.409+09:00 level=ERROR msg=Connector.Connect conn_id=gwFomUACWTjd26ZR duration=780958 error="driver: bad connection"
-time=2025-02-06T22:15:50.409+09:00 level=ERROR msg=Connector.Connect duration=815833 error="driver: bad connection"
-time=2025-02-06T22:15:50.409+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:50.409+09:00 level=DEBUG msg=Connector.Connect conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:50.410+09:00 level=ERROR msg=Connector.Connect conn_id=gwFomUACWTjd26ZR duration=529042 error="driver: bad connection"
-time=2025-02-06T22:15:50.410+09:00 level=ERROR msg=Connector.Connect duration=585791 error="driver: bad connection"
-time=2025-02-06T22:15:52.411+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:52.411+09:00 level=DEBUG msg=Connector.Connect conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:52.416+09:00 level=INFO msg=Connector.Connect conn_id=gwFomUACWTjd26ZR duration=5195083
-time=2025-02-06T22:15:52.416+09:00 level=INFO msg=Connector.Connect duration=5396708
-time=2025-02-06T22:15:52.417+09:00 level=DEBUG msg=Conn.ExecContext conn_id=gwFomUACWTjd26ZR query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-06T22:15:52.438+09:00 level=INFO msg=Conn.ExecContext conn_id=gwFomUACWTjd26ZR query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=20467000
-time=2025-02-06T22:15:52.438+09:00 level=DEBUG msg=Conn.BeginTx conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:52.439+09:00 level=INFO msg=Conn.BeginTx conn_id=gwFomUACWTjd26ZR duration=399959 tx_id=nDmQwJ2r7ZX4fpUE
-time=2025-02-06T22:15:52.439+09:00 level=DEBUG msg=Conn.ExecContext conn_id=gwFomUACWTjd26ZR query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-06T22:15:52.439+09:00 level=INFO msg=Conn.ExecContext conn_id=gwFomUACWTjd26ZR query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=750 skip=true
-time=2025-02-06T22:15:52.439+09:00 level=DEBUG msg=Conn.PrepareContext conn_id=gwFomUACWTjd26ZR query="INSERT INTO test1 (id, name) VALUES (?, ?)"
-time=2025-02-06T22:15:52.441+09:00 level=INFO msg=Conn.PrepareContext conn_id=gwFomUACWTjd26ZR query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=2006000 stmt_id=g_gi7BpanoDDAGhd
-time=2025-02-06T22:15:52.441+09:00 level=DEBUG msg=Stmt.ExecContext conn_id=gwFomUACWTjd26ZR stmt_id=g_gi7BpanoDDAGhd args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-06T22:15:52.442+09:00 level=INFO msg=Stmt.ExecContext conn_id=gwFomUACWTjd26ZR stmt_id=g_gi7BpanoDDAGhd args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=514834
-time=2025-02-06T22:15:52.442+09:00 level=DEBUG msg=Stmt.Close conn_id=gwFomUACWTjd26ZR stmt_id=g_gi7BpanoDDAGhd
-time=2025-02-06T22:15:52.442+09:00 level=INFO msg=Stmt.Close conn_id=gwFomUACWTjd26ZR stmt_id=g_gi7BpanoDDAGhd duration=10375
-time=2025-02-06T22:15:52.442+09:00 level=DEBUG msg=Tx.Commit conn_id=gwFomUACWTjd26ZR tx_id=nDmQwJ2r7ZX4fpUE
-time=2025-02-06T22:15:52.443+09:00 level=INFO msg=Tx.Commit conn_id=gwFomUACWTjd26ZR tx_id=nDmQwJ2r7ZX4fpUE duration=1500208
-time=2025-02-06T22:15:52.444+09:00 level=DEBUG msg=Conn.QueryContext conn_id=gwFomUACWTjd26ZR query="SELECT * FROM test1" args=[] duration=529125
-time=2025-02-06T22:15:52.444+09:00 level=DEBUG msg=Rows.Next conn_id=gwFomUACWTjd26ZR duration=21875 eof=false
-time=2025-02-06T22:15:52.444+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-06T22:15:52.444+09:00 level=DEBUG msg=Rows.Next conn_id=gwFomUACWTjd26ZR duration=83 eof=true
-time=2025-02-06T22:15:52.444+09:00 level=DEBUG msg=Rows.Close conn_id=gwFomUACWTjd26ZR duration=792
-time=2025-02-06T22:15:52.444+09:00 level=DEBUG msg=Conn.Close conn_id=gwFomUACWTjd26ZR
-time=2025-02-06T22:15:52.444+09:00 level=INFO msg=Conn.Close conn_id=gwFomUACWTjd26ZR duration=33792
+time=2025-02-19T08:00:11.509+09:00 level=DEBUG msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1
+time=2025-02-19T08:00:11.510+09:00 level=DEBUG msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1
+time=2025-02-19T08:00:11.510+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=3333 conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:11.510+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=185291
+time=2025-02-19T08:00:11.510+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:11.510+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:11.513+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=2852042 error="driver: bad connection"
+time=2025-02-19T08:00:11.513+09:00 level=ERROR msg=Connector.Connect duration=2934334 error="driver: bad connection"
+time=2025-02-19T08:00:11.513+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:11.513+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:11.514+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=722541 error="driver: bad connection"
+time=2025-02-19T08:00:11.514+09:00 level=ERROR msg=Connector.Connect duration=779958 error="driver: bad connection"
+time=2025-02-19T08:00:11.514+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:11.514+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:11.514+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=506791 error="driver: bad connection"
+time=2025-02-19T08:00:11.514+09:00 level=ERROR msg=Connector.Connect duration=535875 error="driver: bad connection"
+time=2025-02-19T08:00:13.515+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:13.515+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:13.518+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=2542416 error="driver: bad connection"
+time=2025-02-19T08:00:13.518+09:00 level=ERROR msg=Connector.Connect duration=2574000 error="driver: bad connection"
+time=2025-02-19T08:00:13.518+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:13.518+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:13.519+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=891583 error="driver: bad connection"
+time=2025-02-19T08:00:13.519+09:00 level=ERROR msg=Connector.Connect duration=907958 error="driver: bad connection"
+time=2025-02-19T08:00:13.519+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:13.519+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:13.520+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=718791 error="driver: bad connection"
+time=2025-02-19T08:00:13.520+09:00 level=ERROR msg=Connector.Connect duration=731958 error="driver: bad connection"
+time=2025-02-19T08:00:15.521+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:15.521+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:15.523+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=2072375 error="driver: bad connection"
+time=2025-02-19T08:00:15.523+09:00 level=ERROR msg=Connector.Connect duration=2203833 error="driver: bad connection"
+time=2025-02-19T08:00:15.523+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:15.523+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:15.524+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=650042 error="driver: bad connection"
+time=2025-02-19T08:00:15.524+09:00 level=ERROR msg=Connector.Connect duration=704625 error="driver: bad connection"
+time=2025-02-19T08:00:15.524+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:15.524+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:15.524+09:00 level=ERROR msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=581417 error="driver: bad connection"
+time=2025-02-19T08:00:15.524+09:00 level=ERROR msg=Connector.Connect duration=627750 error="driver: bad connection"
+time=2025-02-19T08:00:17.526+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:17.526+09:00 level=DEBUG msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:17.531+09:00 level=INFO msg=Connector.Connect conn_id=4wu72jGCoqbIjAb6 duration=5497500
+time=2025-02-19T08:00:17.531+09:00 level=INFO msg=Connector.Connect duration=5671708
+time=2025-02-19T08:00:17.532+09:00 level=DEBUG msg=Conn.ExecContext conn_id=4wu72jGCoqbIjAb6 query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:00:17.551+09:00 level=INFO msg=Conn.ExecContext conn_id=4wu72jGCoqbIjAb6 query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=19095459
+time=2025-02-19T08:00:17.552+09:00 level=DEBUG msg=Conn.BeginTx conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:17.553+09:00 level=INFO msg=Conn.BeginTx conn_id=4wu72jGCoqbIjAb6 duration=588292 tx_id=MDgM3Y429sgIDDJw
+time=2025-02-19T08:00:17.553+09:00 level=DEBUG msg=Conn.ExecContext conn_id=4wu72jGCoqbIjAb6 query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:00:17.553+09:00 level=INFO msg=Conn.ExecContext conn_id=4wu72jGCoqbIjAb6 query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1625 skip=true
+time=2025-02-19T08:00:17.553+09:00 level=DEBUG msg=Conn.PrepareContext conn_id=4wu72jGCoqbIjAb6 query="INSERT INTO test1 (id, name) VALUES (?, ?)"
+time=2025-02-19T08:00:17.557+09:00 level=INFO msg=Conn.PrepareContext conn_id=4wu72jGCoqbIjAb6 query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=4153875 stmt_id=u0A18CtK4S31a60Y
+time=2025-02-19T08:00:17.557+09:00 level=DEBUG msg=Stmt.ExecContext conn_id=4wu72jGCoqbIjAb6 stmt_id=u0A18CtK4S31a60Y args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:00:17.558+09:00 level=INFO msg=Stmt.ExecContext conn_id=4wu72jGCoqbIjAb6 stmt_id=u0A18CtK4S31a60Y args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=569458
+time=2025-02-19T08:00:17.558+09:00 level=DEBUG msg=Stmt.Close conn_id=4wu72jGCoqbIjAb6 stmt_id=u0A18CtK4S31a60Y
+time=2025-02-19T08:00:17.558+09:00 level=INFO msg=Stmt.Close conn_id=4wu72jGCoqbIjAb6 stmt_id=u0A18CtK4S31a60Y duration=10458
+time=2025-02-19T08:00:17.558+09:00 level=DEBUG msg=Tx.Commit conn_id=4wu72jGCoqbIjAb6 tx_id=MDgM3Y429sgIDDJw
+time=2025-02-19T08:00:17.560+09:00 level=INFO msg=Tx.Commit conn_id=4wu72jGCoqbIjAb6 tx_id=MDgM3Y429sgIDDJw duration=1713000
+time=2025-02-19T08:00:17.560+09:00 level=DEBUG msg=Conn.QueryContext conn_id=4wu72jGCoqbIjAb6 query="SELECT * FROM test1" args=[] duration=505917
+time=2025-02-19T08:00:17.560+09:00 level=DEBUG msg=Rows.Next conn_id=4wu72jGCoqbIjAb6 duration=52500 eof=false
+time=2025-02-19T08:00:17.561+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:00:17.561+09:00 level=DEBUG msg=Rows.Next conn_id=4wu72jGCoqbIjAb6 duration=208 eof=true
+time=2025-02-19T08:00:17.561+09:00 level=DEBUG msg=Rows.Close conn_id=4wu72jGCoqbIjAb6 duration=625
+time=2025-02-19T08:00:17.561+09:00 level=DEBUG msg=Conn.Close conn_id=4wu72jGCoqbIjAb6
+time=2025-02-19T08:00:17.561+09:00 level=INFO msg=Conn.Close conn_id=4wu72jGCoqbIjAb6 duration=33083

--- a/examples/logs-mysql/results/info-log.txt
+++ b/examples/logs-mysql/results/info-log.txt
@@ -1,32 +1,32 @@
 go run . info text
-time=2025-02-06T22:15:38.574+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=14500 conn_id=kbL4lDUQADOB8t9J
-time=2025-02-06T22:15:38.574+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=543583
-time=2025-02-06T22:15:38.576+09:00 level=ERROR msg=Connector.Connect conn_id=kbL4lDUQADOB8t9J duration=2455542 error="driver: bad connection"
-time=2025-02-06T22:15:38.576+09:00 level=ERROR msg=Connector.Connect duration=2563041 error="driver: bad connection"
-time=2025-02-06T22:15:38.577+09:00 level=ERROR msg=Connector.Connect conn_id=kbL4lDUQADOB8t9J duration=674458 error="driver: bad connection"
-time=2025-02-06T22:15:38.577+09:00 level=ERROR msg=Connector.Connect duration=705958 error="driver: bad connection"
-time=2025-02-06T22:15:38.580+09:00 level=ERROR msg=Connector.Connect conn_id=kbL4lDUQADOB8t9J duration=2402083 error="driver: bad connection"
-time=2025-02-06T22:15:38.580+09:00 level=ERROR msg=Connector.Connect duration=2438708 error="driver: bad connection"
-time=2025-02-06T22:15:40.585+09:00 level=ERROR msg=Connector.Connect conn_id=kbL4lDUQADOB8t9J duration=4031500 error="driver: bad connection"
-time=2025-02-06T22:15:40.585+09:00 level=ERROR msg=Connector.Connect duration=4222625 error="driver: bad connection"
-time=2025-02-06T22:15:40.587+09:00 level=ERROR msg=Connector.Connect conn_id=kbL4lDUQADOB8t9J duration=1994542 error="driver: bad connection"
-time=2025-02-06T22:15:40.587+09:00 level=ERROR msg=Connector.Connect duration=2101166 error="driver: bad connection"
-time=2025-02-06T22:15:40.590+09:00 level=ERROR msg=Connector.Connect conn_id=kbL4lDUQADOB8t9J duration=2955084 error="driver: bad connection"
-time=2025-02-06T22:15:40.590+09:00 level=ERROR msg=Connector.Connect duration=3053625 error="driver: bad connection"
-time=2025-02-06T22:15:42.593+09:00 level=ERROR msg=Connector.Connect conn_id=kbL4lDUQADOB8t9J duration=1160000 error="driver: bad connection"
-time=2025-02-06T22:15:42.593+09:00 level=ERROR msg=Connector.Connect duration=1211958 error="driver: bad connection"
-time=2025-02-06T22:15:42.593+09:00 level=ERROR msg=Connector.Connect conn_id=kbL4lDUQADOB8t9J duration=615083 error="driver: bad connection"
-time=2025-02-06T22:15:42.593+09:00 level=ERROR msg=Connector.Connect duration=642250 error="driver: bad connection"
-time=2025-02-06T22:15:42.594+09:00 level=ERROR msg=Connector.Connect conn_id=kbL4lDUQADOB8t9J duration=1220417 error="driver: bad connection"
-time=2025-02-06T22:15:42.594+09:00 level=ERROR msg=Connector.Connect duration=1242583 error="driver: bad connection"
-time=2025-02-06T22:15:44.601+09:00 level=INFO msg=Connector.Connect conn_id=kbL4lDUQADOB8t9J duration=5734958
-time=2025-02-06T22:15:44.601+09:00 level=INFO msg=Connector.Connect duration=5874084
-time=2025-02-06T22:15:44.623+09:00 level=INFO msg=Conn.ExecContext conn_id=kbL4lDUQADOB8t9J query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=21004250
-time=2025-02-06T22:15:44.624+09:00 level=INFO msg=Conn.BeginTx conn_id=kbL4lDUQADOB8t9J duration=546917 tx_id=fgrzadLc3UrASQB6
-time=2025-02-06T22:15:44.624+09:00 level=INFO msg=Conn.ExecContext conn_id=kbL4lDUQADOB8t9J query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1167 skip=true
-time=2025-02-06T22:15:44.628+09:00 level=INFO msg=Conn.PrepareContext conn_id=kbL4lDUQADOB8t9J query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=3232250 stmt_id=tKmjmnFxKS9uli8J
-time=2025-02-06T22:15:44.628+09:00 level=INFO msg=Stmt.ExecContext conn_id=kbL4lDUQADOB8t9J stmt_id=tKmjmnFxKS9uli8J args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=524333
-time=2025-02-06T22:15:44.628+09:00 level=INFO msg=Stmt.Close conn_id=kbL4lDUQADOB8t9J stmt_id=tKmjmnFxKS9uli8J duration=19708
-time=2025-02-06T22:15:44.630+09:00 level=INFO msg=Tx.Commit conn_id=kbL4lDUQADOB8t9J tx_id=fgrzadLc3UrASQB6 duration=1555917
-time=2025-02-06T22:15:44.631+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-06T22:15:44.631+09:00 level=INFO msg=Conn.Close conn_id=kbL4lDUQADOB8t9J duration=63292
+time=2025-02-19T08:00:03.968+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=9958 conn_id=L5FejnVbuaatgJ3q
+time=2025-02-19T08:00:03.968+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=399000
+time=2025-02-19T08:00:03.971+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=2283708 error="driver: bad connection"
+time=2025-02-19T08:00:03.971+09:00 level=ERROR msg=Connector.Connect duration=2299917 error="driver: bad connection"
+time=2025-02-19T08:00:03.972+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=892875 error="driver: bad connection"
+time=2025-02-19T08:00:03.972+09:00 level=ERROR msg=Connector.Connect duration=930125 error="driver: bad connection"
+time=2025-02-19T08:00:03.972+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=647791 error="driver: bad connection"
+time=2025-02-19T08:00:03.972+09:00 level=ERROR msg=Connector.Connect duration=658500 error="driver: bad connection"
+time=2025-02-19T08:00:05.978+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=4091875 error="driver: bad connection"
+time=2025-02-19T08:00:05.978+09:00 level=ERROR msg=Connector.Connect duration=4302084 error="driver: bad connection"
+time=2025-02-19T08:00:05.980+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=2089583 error="driver: bad connection"
+time=2025-02-19T08:00:05.980+09:00 level=ERROR msg=Connector.Connect duration=2184958 error="driver: bad connection"
+time=2025-02-19T08:00:05.982+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=2026792 error="driver: bad connection"
+time=2025-02-19T08:00:05.982+09:00 level=ERROR msg=Connector.Connect duration=2150959 error="driver: bad connection"
+time=2025-02-19T08:00:07.984+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=1927875 error="driver: bad connection"
+time=2025-02-19T08:00:07.985+09:00 level=ERROR msg=Connector.Connect duration=2020666 error="driver: bad connection"
+time=2025-02-19T08:00:07.985+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=598875 error="driver: bad connection"
+time=2025-02-19T08:00:07.985+09:00 level=ERROR msg=Connector.Connect duration=674334 error="driver: bad connection"
+time=2025-02-19T08:00:07.986+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=575542 error="driver: bad connection"
+time=2025-02-19T08:00:07.986+09:00 level=ERROR msg=Connector.Connect duration=604292 error="driver: bad connection"
+time=2025-02-19T08:00:09.992+09:00 level=INFO msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=5304167
+time=2025-02-19T08:00:09.992+09:00 level=INFO msg=Connector.Connect duration=5425833
+time=2025-02-19T08:00:10.013+09:00 level=INFO msg=Conn.ExecContext conn_id=L5FejnVbuaatgJ3q query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=20287375
+time=2025-02-19T08:00:10.015+09:00 level=INFO msg=Conn.BeginTx conn_id=L5FejnVbuaatgJ3q duration=637209 tx_id=eNCpFZLq7stiSzgv
+time=2025-02-19T08:00:10.015+09:00 level=INFO msg=Conn.ExecContext conn_id=L5FejnVbuaatgJ3q query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=833 skip=true
+time=2025-02-19T08:00:10.017+09:00 level=INFO msg=Conn.PrepareContext conn_id=L5FejnVbuaatgJ3q query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=2503667 stmt_id=O4JrFaYyin0Yw8DP
+time=2025-02-19T08:00:10.018+09:00 level=INFO msg=Stmt.ExecContext conn_id=L5FejnVbuaatgJ3q stmt_id=O4JrFaYyin0Yw8DP args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=547083
+time=2025-02-19T08:00:10.018+09:00 level=INFO msg=Stmt.Close conn_id=L5FejnVbuaatgJ3q stmt_id=O4JrFaYyin0Yw8DP duration=7250
+time=2025-02-19T08:00:10.020+09:00 level=INFO msg=Tx.Commit conn_id=L5FejnVbuaatgJ3q tx_id=eNCpFZLq7stiSzgv duration=1782541
+time=2025-02-19T08:00:10.020+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:00:10.020+09:00 level=INFO msg=Conn.Close conn_id=L5FejnVbuaatgJ3q duration=25750

--- a/examples/logs-mysql/results/info-log.txt
+++ b/examples/logs-mysql/results/info-log.txt
@@ -1,32 +1,31 @@
-go run . info text
-time=2025-02-19T08:00:03.968+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=9958 conn_id=L5FejnVbuaatgJ3q
-time=2025-02-19T08:00:03.968+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=399000
-time=2025-02-19T08:00:03.971+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=2283708 error="driver: bad connection"
-time=2025-02-19T08:00:03.971+09:00 level=ERROR msg=Connector.Connect duration=2299917 error="driver: bad connection"
-time=2025-02-19T08:00:03.972+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=892875 error="driver: bad connection"
-time=2025-02-19T08:00:03.972+09:00 level=ERROR msg=Connector.Connect duration=930125 error="driver: bad connection"
-time=2025-02-19T08:00:03.972+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=647791 error="driver: bad connection"
-time=2025-02-19T08:00:03.972+09:00 level=ERROR msg=Connector.Connect duration=658500 error="driver: bad connection"
-time=2025-02-19T08:00:05.978+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=4091875 error="driver: bad connection"
-time=2025-02-19T08:00:05.978+09:00 level=ERROR msg=Connector.Connect duration=4302084 error="driver: bad connection"
-time=2025-02-19T08:00:05.980+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=2089583 error="driver: bad connection"
-time=2025-02-19T08:00:05.980+09:00 level=ERROR msg=Connector.Connect duration=2184958 error="driver: bad connection"
-time=2025-02-19T08:00:05.982+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=2026792 error="driver: bad connection"
-time=2025-02-19T08:00:05.982+09:00 level=ERROR msg=Connector.Connect duration=2150959 error="driver: bad connection"
-time=2025-02-19T08:00:07.984+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=1927875 error="driver: bad connection"
-time=2025-02-19T08:00:07.985+09:00 level=ERROR msg=Connector.Connect duration=2020666 error="driver: bad connection"
-time=2025-02-19T08:00:07.985+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=598875 error="driver: bad connection"
-time=2025-02-19T08:00:07.985+09:00 level=ERROR msg=Connector.Connect duration=674334 error="driver: bad connection"
-time=2025-02-19T08:00:07.986+09:00 level=ERROR msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=575542 error="driver: bad connection"
-time=2025-02-19T08:00:07.986+09:00 level=ERROR msg=Connector.Connect duration=604292 error="driver: bad connection"
-time=2025-02-19T08:00:09.992+09:00 level=INFO msg=Connector.Connect conn_id=L5FejnVbuaatgJ3q duration=5304167
-time=2025-02-19T08:00:09.992+09:00 level=INFO msg=Connector.Connect duration=5425833
-time=2025-02-19T08:00:10.013+09:00 level=INFO msg=Conn.ExecContext conn_id=L5FejnVbuaatgJ3q query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=20287375
-time=2025-02-19T08:00:10.015+09:00 level=INFO msg=Conn.BeginTx conn_id=L5FejnVbuaatgJ3q duration=637209 tx_id=eNCpFZLq7stiSzgv
-time=2025-02-19T08:00:10.015+09:00 level=INFO msg=Conn.ExecContext conn_id=L5FejnVbuaatgJ3q query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=833 skip=true
-time=2025-02-19T08:00:10.017+09:00 level=INFO msg=Conn.PrepareContext conn_id=L5FejnVbuaatgJ3q query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=2503667 stmt_id=O4JrFaYyin0Yw8DP
-time=2025-02-19T08:00:10.018+09:00 level=INFO msg=Stmt.ExecContext conn_id=L5FejnVbuaatgJ3q stmt_id=O4JrFaYyin0Yw8DP args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=547083
-time=2025-02-19T08:00:10.018+09:00 level=INFO msg=Stmt.Close conn_id=L5FejnVbuaatgJ3q stmt_id=O4JrFaYyin0Yw8DP duration=7250
-time=2025-02-19T08:00:10.020+09:00 level=INFO msg=Tx.Commit conn_id=L5FejnVbuaatgJ3q tx_id=eNCpFZLq7stiSzgv duration=1782541
-time=2025-02-19T08:00:10.020+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-19T08:00:10.020+09:00 level=INFO msg=Conn.Close conn_id=L5FejnVbuaatgJ3q duration=25750
+time=2025-02-19T08:24:52.280+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=16208 conn_id=clbVGbfgqOhHOilv
+time=2025-02-19T08:24:52.281+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=526584
+time=2025-02-19T08:24:52.284+09:00 level=ERROR msg=Connector.Connect conn_id=clbVGbfgqOhHOilv duration=2823792 error="driver: bad connection"
+time=2025-02-19T08:24:52.284+09:00 level=ERROR msg=Connector.Connect duration=2877584 error="driver: bad connection"
+time=2025-02-19T08:24:52.289+09:00 level=ERROR msg=Connector.Connect conn_id=clbVGbfgqOhHOilv duration=5037292 error="driver: bad connection"
+time=2025-02-19T08:24:52.289+09:00 level=ERROR msg=Connector.Connect duration=5073709 error="driver: bad connection"
+time=2025-02-19T08:24:52.290+09:00 level=ERROR msg=Connector.Connect conn_id=clbVGbfgqOhHOilv duration=1040458 error="driver: bad connection"
+time=2025-02-19T08:24:52.290+09:00 level=ERROR msg=Connector.Connect duration=1102916 error="driver: bad connection"
+time=2025-02-19T08:24:54.292+09:00 level=ERROR msg=Connector.Connect conn_id=clbVGbfgqOhHOilv duration=1334625 error="driver: bad connection"
+time=2025-02-19T08:24:54.292+09:00 level=ERROR msg=Connector.Connect duration=1369917 error="driver: bad connection"
+time=2025-02-19T08:24:54.293+09:00 level=ERROR msg=Connector.Connect conn_id=clbVGbfgqOhHOilv duration=725208 error="driver: bad connection"
+time=2025-02-19T08:24:54.293+09:00 level=ERROR msg=Connector.Connect duration=746541 error="driver: bad connection"
+time=2025-02-19T08:24:54.294+09:00 level=ERROR msg=Connector.Connect conn_id=clbVGbfgqOhHOilv duration=747291 error="driver: bad connection"
+time=2025-02-19T08:24:54.294+09:00 level=ERROR msg=Connector.Connect duration=832750 error="driver: bad connection"
+time=2025-02-19T08:24:56.298+09:00 level=ERROR msg=Connector.Connect conn_id=clbVGbfgqOhHOilv duration=2891250 error="driver: bad connection"
+time=2025-02-19T08:24:56.298+09:00 level=ERROR msg=Connector.Connect duration=3038292 error="driver: bad connection"
+time=2025-02-19T08:24:56.299+09:00 level=ERROR msg=Connector.Connect conn_id=clbVGbfgqOhHOilv duration=611542 error="driver: bad connection"
+time=2025-02-19T08:24:56.299+09:00 level=ERROR msg=Connector.Connect duration=641333 error="driver: bad connection"
+time=2025-02-19T08:24:56.300+09:00 level=ERROR msg=Connector.Connect conn_id=clbVGbfgqOhHOilv duration=721334 error="driver: bad connection"
+time=2025-02-19T08:24:56.300+09:00 level=ERROR msg=Connector.Connect duration=769250 error="driver: bad connection"
+time=2025-02-19T08:24:58.307+09:00 level=INFO msg=Connector.Connect conn_id=clbVGbfgqOhHOilv duration=6212333
+time=2025-02-19T08:24:58.307+09:00 level=INFO msg=Connector.Connect duration=6373000
+time=2025-02-19T08:24:58.328+09:00 level=INFO msg=Conn.ExecContext conn_id=clbVGbfgqOhHOilv query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=20119875
+time=2025-02-19T08:24:58.329+09:00 level=INFO msg=Conn.BeginTx conn_id=clbVGbfgqOhHOilv duration=536667 tx_id=IiNjHHNd_eLrgYyb
+time=2025-02-19T08:24:58.330+09:00 level=INFO msg=Conn.ExecContext conn_id=clbVGbfgqOhHOilv query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1209 skip=true
+time=2025-02-19T08:24:58.332+09:00 level=INFO msg=Conn.PrepareContext conn_id=clbVGbfgqOhHOilv query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=2173458 stmt_id=rcBX4pdS0w5Vhglc
+time=2025-02-19T08:24:58.333+09:00 level=INFO msg=Stmt.ExecContext conn_id=clbVGbfgqOhHOilv stmt_id=rcBX4pdS0w5Vhglc args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=605208
+time=2025-02-19T08:24:58.333+09:00 level=INFO msg=Stmt.Close conn_id=clbVGbfgqOhHOilv stmt_id=rcBX4pdS0w5Vhglc duration=22709
+time=2025-02-19T08:24:58.335+09:00 level=INFO msg=Tx.Commit conn_id=clbVGbfgqOhHOilv tx_id=IiNjHHNd_eLrgYyb duration=1991750
+time=2025-02-19T08:24:58.335+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:24:58.336+09:00 level=INFO msg=Conn.Close conn_id=clbVGbfgqOhHOilv duration=50083

--- a/examples/logs-mysql/results/trace-log.txt
+++ b/examples/logs-mysql/results/trace-log.txt
@@ -1,88 +1,76 @@
 go run . trace text
-time=2025-02-06T22:15:54.254+09:00 level=DEBUG msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1
-time=2025-02-06T22:15:54.254+09:00 level=DEBUG msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1
-time=2025-02-06T22:15:54.254+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=3625 conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:15:54.254+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=222417
-time=2025-02-06T22:15:54.254+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:54.254+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:15:54.257+09:00 level=ERROR msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=2700666 error="driver: bad connection"
-time=2025-02-06T22:15:54.257+09:00 level=ERROR msg=Connector.Connect duration=2786792 error="driver: bad connection"
-time=2025-02-06T22:15:54.257+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:54.257+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:15:54.258+09:00 level=ERROR msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=718417 error="driver: bad connection"
-time=2025-02-06T22:15:54.258+09:00 level=ERROR msg=Connector.Connect duration=792500 error="driver: bad connection"
-time=2025-02-06T22:15:54.258+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:54.258+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:15:54.259+09:00 level=ERROR msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=577875 error="driver: bad connection"
-time=2025-02-06T22:15:54.259+09:00 level=ERROR msg=Connector.Connect duration=622083 error="driver: bad connection"
-time=2025-02-06T22:15:56.259+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:56.260+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:15:56.263+09:00 level=ERROR msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=3360625 error="driver: bad connection"
-time=2025-02-06T22:15:56.263+09:00 level=ERROR msg=Connector.Connect duration=3522916 error="driver: bad connection"
-time=2025-02-06T22:15:56.263+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:56.263+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:15:56.265+09:00 level=ERROR msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=2158000 error="driver: bad connection"
-time=2025-02-06T22:15:56.266+09:00 level=ERROR msg=Connector.Connect duration=2283750 error="driver: bad connection"
-time=2025-02-06T22:15:56.266+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:56.266+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:15:56.268+09:00 level=ERROR msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=2176459 error="driver: bad connection"
-time=2025-02-06T22:15:56.268+09:00 level=ERROR msg=Connector.Connect duration=2296583 error="driver: bad connection"
-time=2025-02-06T22:15:58.269+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:58.269+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:15:58.270+09:00 level=ERROR msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=1217459 error="driver: bad connection"
-time=2025-02-06T22:15:58.270+09:00 level=ERROR msg=Connector.Connect duration=1294208 error="driver: bad connection"
-time=2025-02-06T22:15:58.270+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:58.270+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:15:58.271+09:00 level=ERROR msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=561667 error="driver: bad connection"
-time=2025-02-06T22:15:58.271+09:00 level=ERROR msg=Connector.Connect duration=593750 error="driver: bad connection"
-time=2025-02-06T22:15:58.271+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:58.271+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:15:58.272+09:00 level=ERROR msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=572875 error="driver: bad connection"
-time=2025-02-06T22:15:58.272+09:00 level=ERROR msg=Connector.Connect duration=628791 error="driver: bad connection"
-time=2025-02-06T22:16:00.273+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:00.273+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:16:00.276+09:00 level=ERROR msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=3124083 error="driver: bad connection"
-time=2025-02-06T22:16:00.276+09:00 level=ERROR msg=Connector.Connect duration=3281791 error="driver: bad connection"
-time=2025-02-06T22:16:00.276+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:00.276+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:16:00.279+09:00 level=ERROR msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=2843292 error="driver: bad connection"
-time=2025-02-06T22:16:00.279+09:00 level=ERROR msg=Connector.Connect duration=2968166 error="driver: bad connection"
-time=2025-02-06T22:16:00.279+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:00.279+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:16:00.282+09:00 level=ERROR msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=2406083 error="driver: bad connection"
-time=2025-02-06T22:16:00.282+09:00 level=ERROR msg=Connector.Connect duration=2529417 error="driver: bad connection"
-time=2025-02-06T22:16:02.283+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:02.283+09:00 level=DEBUG msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:16:02.289+09:00 level=INFO msg=Connector.Connect conn_id=NSKWVBiJhzj6ZPRw duration=6294375
-time=2025-02-06T22:16:02.290+09:00 level=INFO msg=Connector.Connect duration=6449625
-time=2025-02-06T22:16:02.290+09:00 level=TRACE msg=Conn.Ping conn_id=NSKWVBiJhzj6ZPRw duration=771416
-time=2025-02-06T22:16:02.290+09:00 level=TRACE msg=Conn.ResetSession conn_id=NSKWVBiJhzj6ZPRw duration=9750
-time=2025-02-06T22:16:02.290+09:00 level=DEBUG msg=Conn.ExecContext conn_id=NSKWVBiJhzj6ZPRw query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-06T22:16:02.312+09:00 level=INFO msg=Conn.ExecContext conn_id=NSKWVBiJhzj6ZPRw query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=21585250
-time=2025-02-06T22:16:02.312+09:00 level=TRACE msg=Conn.ResetSession conn_id=NSKWVBiJhzj6ZPRw duration=10667
-time=2025-02-06T22:16:02.313+09:00 level=TRACE msg=Conn.Ping conn_id=NSKWVBiJhzj6ZPRw duration=650750
-time=2025-02-06T22:16:02.313+09:00 level=TRACE msg=Conn.ResetSession conn_id=NSKWVBiJhzj6ZPRw duration=2584
-time=2025-02-06T22:16:02.313+09:00 level=DEBUG msg=Conn.BeginTx conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:16:02.314+09:00 level=INFO msg=Conn.BeginTx conn_id=NSKWVBiJhzj6ZPRw duration=697708 tx_id=dYmAJ1LxMjvL2N60
-time=2025-02-06T22:16:02.314+09:00 level=DEBUG msg=Conn.ExecContext conn_id=NSKWVBiJhzj6ZPRw query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-06T22:16:02.314+09:00 level=INFO msg=Conn.ExecContext conn_id=NSKWVBiJhzj6ZPRw query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=958 skip=true
-time=2025-02-06T22:16:02.314+09:00 level=DEBUG msg=Conn.PrepareContext conn_id=NSKWVBiJhzj6ZPRw query="INSERT INTO test1 (id, name) VALUES (?, ?)"
-time=2025-02-06T22:16:02.320+09:00 level=INFO msg=Conn.PrepareContext conn_id=NSKWVBiJhzj6ZPRw query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=5696041 stmt_id=QLrWJebYvBqTqEMB
-time=2025-02-06T22:16:02.320+09:00 level=DEBUG msg=Stmt.ExecContext conn_id=NSKWVBiJhzj6ZPRw stmt_id=QLrWJebYvBqTqEMB args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-06T22:16:02.320+09:00 level=INFO msg=Stmt.ExecContext conn_id=NSKWVBiJhzj6ZPRw stmt_id=QLrWJebYvBqTqEMB args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=550541
-time=2025-02-06T22:16:02.320+09:00 level=DEBUG msg=Stmt.Close conn_id=NSKWVBiJhzj6ZPRw stmt_id=QLrWJebYvBqTqEMB
-time=2025-02-06T22:16:02.320+09:00 level=INFO msg=Stmt.Close conn_id=NSKWVBiJhzj6ZPRw stmt_id=QLrWJebYvBqTqEMB duration=31375
-time=2025-02-06T22:16:02.320+09:00 level=DEBUG msg=Tx.Commit conn_id=NSKWVBiJhzj6ZPRw tx_id=dYmAJ1LxMjvL2N60
-time=2025-02-06T22:16:02.323+09:00 level=INFO msg=Tx.Commit conn_id=NSKWVBiJhzj6ZPRw tx_id=dYmAJ1LxMjvL2N60 duration=2293250
-time=2025-02-06T22:16:02.323+09:00 level=TRACE msg=Conn.ResetSession conn_id=NSKWVBiJhzj6ZPRw duration=4584
-time=2025-02-06T22:16:02.323+09:00 level=TRACE msg=Conn.QueryContext conn_id=NSKWVBiJhzj6ZPRw query="SELECT * FROM test1" args=[]
-time=2025-02-06T22:16:02.323+09:00 level=DEBUG msg=Conn.QueryContext conn_id=NSKWVBiJhzj6ZPRw query="SELECT * FROM test1" args=[] duration=537375
-time=2025-02-06T22:16:02.324+09:00 level=TRACE msg=Rows.Next conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:16:02.324+09:00 level=DEBUG msg=Rows.Next conn_id=NSKWVBiJhzj6ZPRw duration=28500 eof=false
-time=2025-02-06T22:16:02.324+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-06T22:16:02.324+09:00 level=TRACE msg=Rows.Next conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:16:02.324+09:00 level=DEBUG msg=Rows.Next conn_id=NSKWVBiJhzj6ZPRw duration=167 eof=true
-time=2025-02-06T22:16:02.324+09:00 level=TRACE msg=Rows.Close conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:16:02.324+09:00 level=DEBUG msg=Rows.Close conn_id=NSKWVBiJhzj6ZPRw duration=1125
-time=2025-02-06T22:16:02.324+09:00 level=DEBUG msg=Conn.Close conn_id=NSKWVBiJhzj6ZPRw
-time=2025-02-06T22:16:02.324+09:00 level=INFO msg=Conn.Close conn_id=NSKWVBiJhzj6ZPRw duration=48583
+time=2025-02-19T08:00:18.975+09:00 level=DEBUG msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1
+time=2025-02-19T08:00:18.975+09:00 level=DEBUG msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1
+time=2025-02-19T08:00:18.975+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=2625 conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:18.975+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=173750
+time=2025-02-19T08:00:18.975+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:18.975+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:18.978+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=2614542 error="driver: bad connection"
+time=2025-02-19T08:00:18.978+09:00 level=ERROR msg=Connector.Connect duration=2687416 error="driver: bad connection"
+time=2025-02-19T08:00:18.978+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:18.978+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:18.979+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=601834 error="driver: bad connection"
+time=2025-02-19T08:00:18.979+09:00 level=ERROR msg=Connector.Connect duration=628542 error="driver: bad connection"
+time=2025-02-19T08:00:18.979+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:18.979+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:18.979+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=535625 error="driver: bad connection"
+time=2025-02-19T08:00:18.979+09:00 level=ERROR msg=Connector.Connect duration=563791 error="driver: bad connection"
+time=2025-02-19T08:00:20.980+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:20.980+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:20.983+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=2554709 error="driver: bad connection"
+time=2025-02-19T08:00:20.983+09:00 level=ERROR msg=Connector.Connect duration=2645875 error="driver: bad connection"
+time=2025-02-19T08:00:20.983+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:20.983+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:20.985+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=1848042 error="driver: bad connection"
+time=2025-02-19T08:00:20.985+09:00 level=ERROR msg=Connector.Connect duration=1902875 error="driver: bad connection"
+time=2025-02-19T08:00:20.985+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:20.985+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:20.986+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=673834 error="driver: bad connection"
+time=2025-02-19T08:00:20.986+09:00 level=ERROR msg=Connector.Connect duration=711292 error="driver: bad connection"
+time=2025-02-19T08:00:22.987+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:22.987+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:22.990+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=3692791 error="driver: bad connection"
+time=2025-02-19T08:00:22.991+09:00 level=ERROR msg=Connector.Connect duration=3893083 error="driver: bad connection"
+time=2025-02-19T08:00:22.991+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:22.991+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:22.993+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=2303500 error="driver: bad connection"
+time=2025-02-19T08:00:22.993+09:00 level=ERROR msg=Connector.Connect duration=2434417 error="driver: bad connection"
+time=2025-02-19T08:00:22.993+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:22.993+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:22.995+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=2060833 error="driver: bad connection"
+time=2025-02-19T08:00:22.995+09:00 level=ERROR msg=Connector.Connect duration=2219500 error="driver: bad connection"
+time=2025-02-19T08:00:24.997+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:24.997+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:25.003+09:00 level=INFO msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=5904875
+time=2025-02-19T08:00:25.003+09:00 level=INFO msg=Connector.Connect duration=6079542
+time=2025-02-19T08:00:25.004+09:00 level=TRACE msg=Conn.Ping conn_id=2Q1kHybFPffIv12k duration=1202708
+time=2025-02-19T08:00:25.004+09:00 level=TRACE msg=Conn.ResetSession conn_id=2Q1kHybFPffIv12k duration=11667
+time=2025-02-19T08:00:25.004+09:00 level=DEBUG msg=Conn.ExecContext conn_id=2Q1kHybFPffIv12k query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:00:25.020+09:00 level=INFO msg=Conn.ExecContext conn_id=2Q1kHybFPffIv12k query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=15883666
+time=2025-02-19T08:00:25.020+09:00 level=TRACE msg=Conn.ResetSession conn_id=2Q1kHybFPffIv12k duration=5458
+time=2025-02-19T08:00:25.021+09:00 level=TRACE msg=Conn.Ping conn_id=2Q1kHybFPffIv12k duration=464208
+time=2025-02-19T08:00:25.021+09:00 level=TRACE msg=Conn.ResetSession conn_id=2Q1kHybFPffIv12k duration=1791
+time=2025-02-19T08:00:25.021+09:00 level=DEBUG msg=Conn.BeginTx conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:25.021+09:00 level=INFO msg=Conn.BeginTx conn_id=2Q1kHybFPffIv12k duration=385875 tx_id=OMPbWSatxu91zTTO
+time=2025-02-19T08:00:25.021+09:00 level=DEBUG msg=Conn.ExecContext conn_id=2Q1kHybFPffIv12k query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:00:25.021+09:00 level=INFO msg=Conn.ExecContext conn_id=2Q1kHybFPffIv12k query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=833 skip=true
+time=2025-02-19T08:00:25.021+09:00 level=DEBUG msg=Conn.PrepareContext conn_id=2Q1kHybFPffIv12k query="INSERT INTO test1 (id, name) VALUES (?, ?)"
+time=2025-02-19T08:00:25.025+09:00 level=INFO msg=Conn.PrepareContext conn_id=2Q1kHybFPffIv12k query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=3255459 stmt_id=JQk2Wd1_WQsAEP2X
+time=2025-02-19T08:00:25.025+09:00 level=DEBUG msg=Stmt.ExecContext conn_id=2Q1kHybFPffIv12k stmt_id=JQk2Wd1_WQsAEP2X args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:00:25.025+09:00 level=INFO msg=Stmt.ExecContext conn_id=2Q1kHybFPffIv12k stmt_id=JQk2Wd1_WQsAEP2X args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=718375
+time=2025-02-19T08:00:25.025+09:00 level=DEBUG msg=Stmt.Close conn_id=2Q1kHybFPffIv12k stmt_id=JQk2Wd1_WQsAEP2X
+time=2025-02-19T08:00:25.025+09:00 level=INFO msg=Stmt.Close conn_id=2Q1kHybFPffIv12k stmt_id=JQk2Wd1_WQsAEP2X duration=6917
+time=2025-02-19T08:00:25.026+09:00 level=DEBUG msg=Tx.Commit conn_id=2Q1kHybFPffIv12k tx_id=OMPbWSatxu91zTTO
+time=2025-02-19T08:00:25.028+09:00 level=INFO msg=Tx.Commit conn_id=2Q1kHybFPffIv12k tx_id=OMPbWSatxu91zTTO duration=2356250
+time=2025-02-19T08:00:25.028+09:00 level=TRACE msg=Conn.ResetSession conn_id=2Q1kHybFPffIv12k duration=6667
+time=2025-02-19T08:00:25.028+09:00 level=TRACE msg=Conn.QueryContext conn_id=2Q1kHybFPffIv12k query="SELECT * FROM test1" args=[]
+time=2025-02-19T08:00:25.029+09:00 level=DEBUG msg=Conn.QueryContext conn_id=2Q1kHybFPffIv12k query="SELECT * FROM test1" args=[] duration=624459
+time=2025-02-19T08:00:25.029+09:00 level=TRACE msg=Rows.Next conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:25.029+09:00 level=DEBUG msg=Rows.Next conn_id=2Q1kHybFPffIv12k duration=39875 eof=false
+time=2025-02-19T08:00:25.029+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:00:25.029+09:00 level=TRACE msg=Rows.Next conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:25.029+09:00 level=DEBUG msg=Rows.Next conn_id=2Q1kHybFPffIv12k duration=125 eof=true
+time=2025-02-19T08:00:25.029+09:00 level=TRACE msg=Rows.Close conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:25.029+09:00 level=DEBUG msg=Rows.Close conn_id=2Q1kHybFPffIv12k duration=625
+time=2025-02-19T08:00:25.029+09:00 level=DEBUG msg=Conn.Close conn_id=2Q1kHybFPffIv12k
+time=2025-02-19T08:00:25.029+09:00 level=INFO msg=Conn.Close conn_id=2Q1kHybFPffIv12k duration=35542

--- a/examples/logs-mysql/results/trace-log.txt
+++ b/examples/logs-mysql/results/trace-log.txt
@@ -1,76 +1,75 @@
-go run . trace text
-time=2025-02-19T08:00:18.975+09:00 level=DEBUG msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1
-time=2025-02-19T08:00:18.975+09:00 level=DEBUG msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1
-time=2025-02-19T08:00:18.975+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=2625 conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:18.975+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=173750
-time=2025-02-19T08:00:18.975+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:18.975+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:18.978+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=2614542 error="driver: bad connection"
-time=2025-02-19T08:00:18.978+09:00 level=ERROR msg=Connector.Connect duration=2687416 error="driver: bad connection"
-time=2025-02-19T08:00:18.978+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:18.978+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:18.979+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=601834 error="driver: bad connection"
-time=2025-02-19T08:00:18.979+09:00 level=ERROR msg=Connector.Connect duration=628542 error="driver: bad connection"
-time=2025-02-19T08:00:18.979+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:18.979+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:18.979+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=535625 error="driver: bad connection"
-time=2025-02-19T08:00:18.979+09:00 level=ERROR msg=Connector.Connect duration=563791 error="driver: bad connection"
-time=2025-02-19T08:00:20.980+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:20.980+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:20.983+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=2554709 error="driver: bad connection"
-time=2025-02-19T08:00:20.983+09:00 level=ERROR msg=Connector.Connect duration=2645875 error="driver: bad connection"
-time=2025-02-19T08:00:20.983+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:20.983+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:20.985+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=1848042 error="driver: bad connection"
-time=2025-02-19T08:00:20.985+09:00 level=ERROR msg=Connector.Connect duration=1902875 error="driver: bad connection"
-time=2025-02-19T08:00:20.985+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:20.985+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:20.986+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=673834 error="driver: bad connection"
-time=2025-02-19T08:00:20.986+09:00 level=ERROR msg=Connector.Connect duration=711292 error="driver: bad connection"
-time=2025-02-19T08:00:22.987+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:22.987+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:22.990+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=3692791 error="driver: bad connection"
-time=2025-02-19T08:00:22.991+09:00 level=ERROR msg=Connector.Connect duration=3893083 error="driver: bad connection"
-time=2025-02-19T08:00:22.991+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:22.991+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:22.993+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=2303500 error="driver: bad connection"
-time=2025-02-19T08:00:22.993+09:00 level=ERROR msg=Connector.Connect duration=2434417 error="driver: bad connection"
-time=2025-02-19T08:00:22.993+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:22.993+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:22.995+09:00 level=ERROR msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=2060833 error="driver: bad connection"
-time=2025-02-19T08:00:22.995+09:00 level=ERROR msg=Connector.Connect duration=2219500 error="driver: bad connection"
-time=2025-02-19T08:00:24.997+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:24.997+09:00 level=DEBUG msg=Connector.Connect conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:25.003+09:00 level=INFO msg=Connector.Connect conn_id=2Q1kHybFPffIv12k duration=5904875
-time=2025-02-19T08:00:25.003+09:00 level=INFO msg=Connector.Connect duration=6079542
-time=2025-02-19T08:00:25.004+09:00 level=TRACE msg=Conn.Ping conn_id=2Q1kHybFPffIv12k duration=1202708
-time=2025-02-19T08:00:25.004+09:00 level=TRACE msg=Conn.ResetSession conn_id=2Q1kHybFPffIv12k duration=11667
-time=2025-02-19T08:00:25.004+09:00 level=DEBUG msg=Conn.ExecContext conn_id=2Q1kHybFPffIv12k query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-19T08:00:25.020+09:00 level=INFO msg=Conn.ExecContext conn_id=2Q1kHybFPffIv12k query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=15883666
-time=2025-02-19T08:00:25.020+09:00 level=TRACE msg=Conn.ResetSession conn_id=2Q1kHybFPffIv12k duration=5458
-time=2025-02-19T08:00:25.021+09:00 level=TRACE msg=Conn.Ping conn_id=2Q1kHybFPffIv12k duration=464208
-time=2025-02-19T08:00:25.021+09:00 level=TRACE msg=Conn.ResetSession conn_id=2Q1kHybFPffIv12k duration=1791
-time=2025-02-19T08:00:25.021+09:00 level=DEBUG msg=Conn.BeginTx conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:25.021+09:00 level=INFO msg=Conn.BeginTx conn_id=2Q1kHybFPffIv12k duration=385875 tx_id=OMPbWSatxu91zTTO
-time=2025-02-19T08:00:25.021+09:00 level=DEBUG msg=Conn.ExecContext conn_id=2Q1kHybFPffIv12k query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-19T08:00:25.021+09:00 level=INFO msg=Conn.ExecContext conn_id=2Q1kHybFPffIv12k query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=833 skip=true
-time=2025-02-19T08:00:25.021+09:00 level=DEBUG msg=Conn.PrepareContext conn_id=2Q1kHybFPffIv12k query="INSERT INTO test1 (id, name) VALUES (?, ?)"
-time=2025-02-19T08:00:25.025+09:00 level=INFO msg=Conn.PrepareContext conn_id=2Q1kHybFPffIv12k query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=3255459 stmt_id=JQk2Wd1_WQsAEP2X
-time=2025-02-19T08:00:25.025+09:00 level=DEBUG msg=Stmt.ExecContext conn_id=2Q1kHybFPffIv12k stmt_id=JQk2Wd1_WQsAEP2X args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-19T08:00:25.025+09:00 level=INFO msg=Stmt.ExecContext conn_id=2Q1kHybFPffIv12k stmt_id=JQk2Wd1_WQsAEP2X args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=718375
-time=2025-02-19T08:00:25.025+09:00 level=DEBUG msg=Stmt.Close conn_id=2Q1kHybFPffIv12k stmt_id=JQk2Wd1_WQsAEP2X
-time=2025-02-19T08:00:25.025+09:00 level=INFO msg=Stmt.Close conn_id=2Q1kHybFPffIv12k stmt_id=JQk2Wd1_WQsAEP2X duration=6917
-time=2025-02-19T08:00:25.026+09:00 level=DEBUG msg=Tx.Commit conn_id=2Q1kHybFPffIv12k tx_id=OMPbWSatxu91zTTO
-time=2025-02-19T08:00:25.028+09:00 level=INFO msg=Tx.Commit conn_id=2Q1kHybFPffIv12k tx_id=OMPbWSatxu91zTTO duration=2356250
-time=2025-02-19T08:00:25.028+09:00 level=TRACE msg=Conn.ResetSession conn_id=2Q1kHybFPffIv12k duration=6667
-time=2025-02-19T08:00:25.028+09:00 level=TRACE msg=Conn.QueryContext conn_id=2Q1kHybFPffIv12k query="SELECT * FROM test1" args=[]
-time=2025-02-19T08:00:25.029+09:00 level=DEBUG msg=Conn.QueryContext conn_id=2Q1kHybFPffIv12k query="SELECT * FROM test1" args=[] duration=624459
-time=2025-02-19T08:00:25.029+09:00 level=TRACE msg=Rows.Next conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:25.029+09:00 level=DEBUG msg=Rows.Next conn_id=2Q1kHybFPffIv12k duration=39875 eof=false
-time=2025-02-19T08:00:25.029+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-19T08:00:25.029+09:00 level=TRACE msg=Rows.Next conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:25.029+09:00 level=DEBUG msg=Rows.Next conn_id=2Q1kHybFPffIv12k duration=125 eof=true
-time=2025-02-19T08:00:25.029+09:00 level=TRACE msg=Rows.Close conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:25.029+09:00 level=DEBUG msg=Rows.Close conn_id=2Q1kHybFPffIv12k duration=625
-time=2025-02-19T08:00:25.029+09:00 level=DEBUG msg=Conn.Close conn_id=2Q1kHybFPffIv12k
-time=2025-02-19T08:00:25.029+09:00 level=INFO msg=Conn.Close conn_id=2Q1kHybFPffIv12k duration=35542
+time=2025-02-19T08:25:07.327+09:00 level=DEBUG msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1
+time=2025-02-19T08:25:07.328+09:00 level=DEBUG msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1
+time=2025-02-19T08:25:07.328+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=2916 conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:07.328+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=212583
+time=2025-02-19T08:25:07.328+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:07.328+09:00 level=DEBUG msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:07.330+09:00 level=ERROR msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8 duration=2366958 error="driver: bad connection"
+time=2025-02-19T08:25:07.330+09:00 level=ERROR msg=Connector.Connect duration=2444959 error="driver: bad connection"
+time=2025-02-19T08:25:07.330+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:07.330+09:00 level=DEBUG msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:07.331+09:00 level=ERROR msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8 duration=616750 error="driver: bad connection"
+time=2025-02-19T08:25:07.331+09:00 level=ERROR msg=Connector.Connect duration=649417 error="driver: bad connection"
+time=2025-02-19T08:25:07.331+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:07.331+09:00 level=DEBUG msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:07.331+09:00 level=ERROR msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8 duration=459750 error="driver: bad connection"
+time=2025-02-19T08:25:07.331+09:00 level=ERROR msg=Connector.Connect duration=490750 error="driver: bad connection"
+time=2025-02-19T08:25:09.333+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:09.333+09:00 level=DEBUG msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:09.337+09:00 level=ERROR msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8 duration=3817458 error="driver: bad connection"
+time=2025-02-19T08:25:09.337+09:00 level=ERROR msg=Connector.Connect duration=4031292 error="driver: bad connection"
+time=2025-02-19T08:25:09.337+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:09.337+09:00 level=DEBUG msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:09.339+09:00 level=ERROR msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8 duration=2189000 error="driver: bad connection"
+time=2025-02-19T08:25:09.339+09:00 level=ERROR msg=Connector.Connect duration=2362875 error="driver: bad connection"
+time=2025-02-19T08:25:09.339+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:09.339+09:00 level=DEBUG msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:09.341+09:00 level=ERROR msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8 duration=1834750 error="driver: bad connection"
+time=2025-02-19T08:25:09.341+09:00 level=ERROR msg=Connector.Connect duration=2001917 error="driver: bad connection"
+time=2025-02-19T08:25:11.343+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:11.343+09:00 level=DEBUG msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:11.345+09:00 level=ERROR msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8 duration=2030375 error="driver: bad connection"
+time=2025-02-19T08:25:11.345+09:00 level=ERROR msg=Connector.Connect duration=2132709 error="driver: bad connection"
+time=2025-02-19T08:25:11.345+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:11.345+09:00 level=DEBUG msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:11.346+09:00 level=ERROR msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8 duration=790917 error="driver: bad connection"
+time=2025-02-19T08:25:11.346+09:00 level=ERROR msg=Connector.Connect duration=848959 error="driver: bad connection"
+time=2025-02-19T08:25:11.346+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:11.346+09:00 level=DEBUG msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:11.346+09:00 level=ERROR msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8 duration=595542 error="driver: bad connection"
+time=2025-02-19T08:25:11.346+09:00 level=ERROR msg=Connector.Connect duration=653125 error="driver: bad connection"
+time=2025-02-19T08:25:13.347+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:13.347+09:00 level=DEBUG msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:13.353+09:00 level=INFO msg=Connector.Connect conn_id=DakzQLN_ilUa3qN8 duration=6077459
+time=2025-02-19T08:25:13.353+09:00 level=INFO msg=Connector.Connect duration=6225750
+time=2025-02-19T08:25:13.354+09:00 level=TRACE msg=Conn.Ping conn_id=DakzQLN_ilUa3qN8 duration=611459
+time=2025-02-19T08:25:13.354+09:00 level=TRACE msg=Conn.ResetSession conn_id=DakzQLN_ilUa3qN8 duration=9000
+time=2025-02-19T08:25:13.354+09:00 level=DEBUG msg=Conn.ExecContext conn_id=DakzQLN_ilUa3qN8 query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:25:13.371+09:00 level=INFO msg=Conn.ExecContext conn_id=DakzQLN_ilUa3qN8 query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=16803250
+time=2025-02-19T08:25:13.371+09:00 level=TRACE msg=Conn.ResetSession conn_id=DakzQLN_ilUa3qN8 duration=5583
+time=2025-02-19T08:25:13.371+09:00 level=TRACE msg=Conn.Ping conn_id=DakzQLN_ilUa3qN8 duration=531583
+time=2025-02-19T08:25:13.371+09:00 level=TRACE msg=Conn.ResetSession conn_id=DakzQLN_ilUa3qN8 duration=2667
+time=2025-02-19T08:25:13.371+09:00 level=DEBUG msg=Conn.BeginTx conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:13.372+09:00 level=INFO msg=Conn.BeginTx conn_id=DakzQLN_ilUa3qN8 duration=634875 tx_id=O85OXklLPYwG90t4
+time=2025-02-19T08:25:13.372+09:00 level=DEBUG msg=Conn.ExecContext conn_id=DakzQLN_ilUa3qN8 query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:25:13.372+09:00 level=INFO msg=Conn.ExecContext conn_id=DakzQLN_ilUa3qN8 query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=875 skip=true
+time=2025-02-19T08:25:13.372+09:00 level=DEBUG msg=Conn.PrepareContext conn_id=DakzQLN_ilUa3qN8 query="INSERT INTO test1 (id, name) VALUES (?, ?)"
+time=2025-02-19T08:25:13.374+09:00 level=INFO msg=Conn.PrepareContext conn_id=DakzQLN_ilUa3qN8 query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=2129541 stmt_id=uw0QbKVPFpGwALfk
+time=2025-02-19T08:25:13.374+09:00 level=DEBUG msg=Stmt.ExecContext conn_id=DakzQLN_ilUa3qN8 stmt_id=uw0QbKVPFpGwALfk args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:25:13.375+09:00 level=INFO msg=Stmt.ExecContext conn_id=DakzQLN_ilUa3qN8 stmt_id=uw0QbKVPFpGwALfk args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=567125
+time=2025-02-19T08:25:13.375+09:00 level=DEBUG msg=Stmt.Close conn_id=DakzQLN_ilUa3qN8 stmt_id=uw0QbKVPFpGwALfk
+time=2025-02-19T08:25:13.375+09:00 level=INFO msg=Stmt.Close conn_id=DakzQLN_ilUa3qN8 stmt_id=uw0QbKVPFpGwALfk duration=22292
+time=2025-02-19T08:25:13.375+09:00 level=DEBUG msg=Tx.Commit conn_id=DakzQLN_ilUa3qN8 tx_id=O85OXklLPYwG90t4
+time=2025-02-19T08:25:13.377+09:00 level=INFO msg=Tx.Commit conn_id=DakzQLN_ilUa3qN8 tx_id=O85OXklLPYwG90t4 duration=1819792
+time=2025-02-19T08:25:13.377+09:00 level=TRACE msg=Conn.ResetSession conn_id=DakzQLN_ilUa3qN8 duration=4875
+time=2025-02-19T08:25:13.377+09:00 level=TRACE msg=Conn.QueryContext conn_id=DakzQLN_ilUa3qN8 query="SELECT * FROM test1" args=[]
+time=2025-02-19T08:25:13.377+09:00 level=DEBUG msg=Conn.QueryContext conn_id=DakzQLN_ilUa3qN8 query="SELECT * FROM test1" args=[] duration=479541
+time=2025-02-19T08:25:13.377+09:00 level=TRACE msg=Rows.Next conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:13.377+09:00 level=DEBUG msg=Rows.Next conn_id=DakzQLN_ilUa3qN8 duration=42042 eof=false
+time=2025-02-19T08:25:13.377+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:25:13.377+09:00 level=TRACE msg=Rows.Next conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:13.377+09:00 level=DEBUG msg=Rows.Next conn_id=DakzQLN_ilUa3qN8 duration=417 eof=true
+time=2025-02-19T08:25:13.378+09:00 level=TRACE msg=Rows.Close conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:13.378+09:00 level=DEBUG msg=Rows.Close conn_id=DakzQLN_ilUa3qN8 duration=625
+time=2025-02-19T08:25:13.378+09:00 level=DEBUG msg=Conn.Close conn_id=DakzQLN_ilUa3qN8
+time=2025-02-19T08:25:13.378+09:00 level=INFO msg=Conn.Close conn_id=DakzQLN_ilUa3qN8 duration=55708

--- a/examples/logs-mysql/results/verbose-log.json
+++ b/examples/logs-mysql/results/verbose-log.json
@@ -1,0 +1,81 @@
+{"time":"2025-02-19T08:25:22.45015+09:00","level":"DEBUG","msg":"Open","driver":"mysql","dsn":"root@tcp(localhost:3306)/app1"}
+{"time":"2025-02-19T08:25:22.450638+09:00","level":"DEBUG","msg":"Driver.OpenConnector","dsn":"root@tcp(localhost:3306)/app1"}
+{"time":"2025-02-19T08:25:22.450681+09:00","level":"INFO","msg":"Driver.OpenConnector","dsn":"root@tcp(localhost:3306)/app1","duration":2708,"conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:22.450706+09:00","level":"INFO","msg":"Open","driver":"mysql","dsn":"root@tcp(localhost:3306)/app1","duration":182875}
+{"time":"2025-02-19T08:25:22.450727+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:25:22.450735+09:00","level":"DEBUG","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:22.453242+09:00","level":"ERROR","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF","duration":2482709,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:22.453298+09:00","level":"ERROR","msg":"Connector.Connect","duration":2561208,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:22.45331+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:25:22.453318+09:00","level":"DEBUG","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:22.453978+09:00","level":"ERROR","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF","duration":649750,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:22.454002+09:00","level":"ERROR","msg":"Connector.Connect","duration":682500,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:22.454011+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:25:22.454019+09:00","level":"DEBUG","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:22.454536+09:00","level":"ERROR","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF","duration":498875,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:22.45457+09:00","level":"ERROR","msg":"Connector.Connect","duration":547875,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:24.455673+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:25:24.455858+09:00","level":"DEBUG","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:24.459087+09:00","level":"ERROR","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF","duration":3182625,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:24.459165+09:00","level":"ERROR","msg":"Connector.Connect","duration":3302709,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:24.459186+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:25:24.459205+09:00","level":"DEBUG","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:24.460775+09:00","level":"ERROR","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF","duration":1548959,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:24.460827+09:00","level":"ERROR","msg":"Connector.Connect","duration":1617125,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:24.460847+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:25:24.460864+09:00","level":"DEBUG","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:24.462354+09:00","level":"ERROR","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF","duration":1464833,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:24.462431+09:00","level":"ERROR","msg":"Connector.Connect","duration":1562125,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:26.462813+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:25:26.462986+09:00","level":"DEBUG","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:26.465019+09:00","level":"ERROR","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF","duration":1947209,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:26.465067+09:00","level":"ERROR","msg":"Connector.Connect","duration":2087958,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:26.465105+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:25:26.465112+09:00","level":"DEBUG","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:26.465831+09:00","level":"ERROR","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF","duration":709750,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:26.465895+09:00","level":"ERROR","msg":"Connector.Connect","duration":774417,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:26.465958+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:25:26.465983+09:00","level":"DEBUG","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:26.466559+09:00","level":"ERROR","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF","duration":567167,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:26.466571+09:00","level":"ERROR","msg":"Connector.Connect","duration":587000,"error":"driver: bad connection"}
+{"time":"2025-02-19T08:25:28.467657+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:25:28.467778+09:00","level":"DEBUG","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:28.473066+09:00","level":"INFO","msg":"Connector.Connect","conn_id":"gUAAxHgPxWhrp2JF","duration":5234417}
+{"time":"2025-02-19T08:25:28.473163+09:00","level":"INFO","msg":"Connector.Connect","duration":5383875}
+{"time":"2025-02-19T08:25:28.473214+09:00","level":"VERBOSE","msg":"Conn.Ping","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:28.474065+09:00","level":"TRACE","msg":"Conn.Ping","conn_id":"gUAAxHgPxWhrp2JF","duration":822000}
+{"time":"2025-02-19T08:25:28.474134+09:00","level":"VERBOSE","msg":"Conn.ResetSession","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:28.474176+09:00","level":"TRACE","msg":"Conn.ResetSession","conn_id":"gUAAxHgPxWhrp2JF","duration":10458}
+{"time":"2025-02-19T08:25:28.474222+09:00","level":"DEBUG","msg":"Conn.ExecContext","conn_id":"gUAAxHgPxWhrp2JF","query":"CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))","args":"[]"}
+{"time":"2025-02-19T08:25:28.494326+09:00","level":"INFO","msg":"Conn.ExecContext","conn_id":"gUAAxHgPxWhrp2JF","query":"CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))","args":"[]","duration":20028084}
+{"time":"2025-02-19T08:25:28.494417+09:00","level":"VERBOSE","msg":"Conn.ResetSession","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:28.494459+09:00","level":"TRACE","msg":"Conn.ResetSession","conn_id":"gUAAxHgPxWhrp2JF","duration":12500}
+{"time":"2025-02-19T08:25:28.494483+09:00","level":"VERBOSE","msg":"Conn.Ping","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:28.495083+09:00","level":"TRACE","msg":"Conn.Ping","conn_id":"gUAAxHgPxWhrp2JF","duration":579417}
+{"time":"2025-02-19T08:25:28.495116+09:00","level":"VERBOSE","msg":"Conn.ResetSession","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:28.495138+09:00","level":"TRACE","msg":"Conn.ResetSession","conn_id":"gUAAxHgPxWhrp2JF","duration":4709}
+{"time":"2025-02-19T08:25:28.495162+09:00","level":"DEBUG","msg":"Conn.BeginTx","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:28.495746+09:00","level":"INFO","msg":"Conn.BeginTx","conn_id":"gUAAxHgPxWhrp2JF","duration":561708,"tx_id":"W46GMOOLwIxg57YM"}
+{"time":"2025-02-19T08:25:28.49591+09:00","level":"DEBUG","msg":"Conn.ExecContext","conn_id":"gUAAxHgPxWhrp2JF","query":"INSERT INTO test1 (id, name) VALUES (?, ?)","args":"[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"}
+{"time":"2025-02-19T08:25:28.495946+09:00","level":"INFO","msg":"Conn.ExecContext","conn_id":"gUAAxHgPxWhrp2JF","query":"INSERT INTO test1 (id, name) VALUES (?, ?)","args":"[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]","duration":1250,"skip":true}
+{"time":"2025-02-19T08:25:28.49597+09:00","level":"DEBUG","msg":"Conn.PrepareContext","conn_id":"gUAAxHgPxWhrp2JF","query":"INSERT INTO test1 (id, name) VALUES (?, ?)"}
+{"time":"2025-02-19T08:25:28.499284+09:00","level":"INFO","msg":"Conn.PrepareContext","conn_id":"gUAAxHgPxWhrp2JF","query":"INSERT INTO test1 (id, name) VALUES (?, ?)","duration":3277250,"stmt_id":"mblHF05jWxqjhG9M"}
+{"time":"2025-02-19T08:25:28.499414+09:00","level":"DEBUG","msg":"Stmt.ExecContext","conn_id":"gUAAxHgPxWhrp2JF","stmt_id":"mblHF05jWxqjhG9M","args":"[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"}
+{"time":"2025-02-19T08:25:28.499952+09:00","level":"INFO","msg":"Stmt.ExecContext","conn_id":"gUAAxHgPxWhrp2JF","stmt_id":"mblHF05jWxqjhG9M","args":"[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]","duration":505125}
+{"time":"2025-02-19T08:25:28.499986+09:00","level":"DEBUG","msg":"Stmt.Close","conn_id":"gUAAxHgPxWhrp2JF","stmt_id":"mblHF05jWxqjhG9M"}
+{"time":"2025-02-19T08:25:28.500029+09:00","level":"INFO","msg":"Stmt.Close","conn_id":"gUAAxHgPxWhrp2JF","stmt_id":"mblHF05jWxqjhG9M","duration":22167}
+{"time":"2025-02-19T08:25:28.500063+09:00","level":"DEBUG","msg":"Tx.Commit","conn_id":"gUAAxHgPxWhrp2JF","tx_id":"W46GMOOLwIxg57YM"}
+{"time":"2025-02-19T08:25:28.50162+09:00","level":"INFO","msg":"Tx.Commit","conn_id":"gUAAxHgPxWhrp2JF","tx_id":"W46GMOOLwIxg57YM","duration":1531875}
+{"time":"2025-02-19T08:25:28.501653+09:00","level":"VERBOSE","msg":"Conn.ResetSession","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:28.501675+09:00","level":"TRACE","msg":"Conn.ResetSession","conn_id":"gUAAxHgPxWhrp2JF","duration":4125}
+{"time":"2025-02-19T08:25:28.5017+09:00","level":"TRACE","msg":"Conn.QueryContext","conn_id":"gUAAxHgPxWhrp2JF","query":"SELECT * FROM test1","args":"[]"}
+{"time":"2025-02-19T08:25:28.502251+09:00","level":"DEBUG","msg":"Conn.QueryContext","conn_id":"gUAAxHgPxWhrp2JF","query":"SELECT * FROM test1","args":"[]","duration":528125}
+{"time":"2025-02-19T08:25:28.502278+09:00","level":"TRACE","msg":"Rows.Next","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:28.502316+09:00","level":"DEBUG","msg":"Rows.Next","conn_id":"gUAAxHgPxWhrp2JF","duration":26334,"eof":false}
+{"time":"2025-02-19T08:25:28.502362+09:00","level":"INFO","msg":"Record","id":1,"name":"Alice"}
+{"time":"2025-02-19T08:25:28.502378+09:00","level":"TRACE","msg":"Rows.Next","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:28.502388+09:00","level":"DEBUG","msg":"Rows.Next","conn_id":"gUAAxHgPxWhrp2JF","duration":250,"eof":true}
+{"time":"2025-02-19T08:25:28.502399+09:00","level":"TRACE","msg":"Rows.Close","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:28.502407+09:00","level":"DEBUG","msg":"Rows.Close","conn_id":"gUAAxHgPxWhrp2JF","duration":500}
+{"time":"2025-02-19T08:25:28.502423+09:00","level":"DEBUG","msg":"Conn.Close","conn_id":"gUAAxHgPxWhrp2JF"}
+{"time":"2025-02-19T08:25:28.502483+09:00","level":"INFO","msg":"Conn.Close","conn_id":"gUAAxHgPxWhrp2JF","duration":50542}

--- a/examples/logs-mysql/results/verbose-log.txt
+++ b/examples/logs-mysql/results/verbose-log.txt
@@ -1,82 +1,81 @@
-go run . verbose text
-time=2025-02-19T08:00:26.813+09:00 level=DEBUG msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1
-time=2025-02-19T08:00:26.813+09:00 level=DEBUG msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1
-time=2025-02-19T08:00:26.813+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=2667 conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:26.813+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=192750
-time=2025-02-19T08:00:26.813+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:26.813+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:26.816+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=2657084 error="driver: bad connection"
-time=2025-02-19T08:00:26.816+09:00 level=ERROR msg=Connector.Connect duration=2730625 error="driver: bad connection"
-time=2025-02-19T08:00:26.816+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:26.816+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:26.817+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=601208 error="driver: bad connection"
-time=2025-02-19T08:00:26.817+09:00 level=ERROR msg=Connector.Connect duration=634125 error="driver: bad connection"
-time=2025-02-19T08:00:26.817+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:26.817+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:26.817+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=479208 error="driver: bad connection"
-time=2025-02-19T08:00:26.817+09:00 level=ERROR msg=Connector.Connect duration=501750 error="driver: bad connection"
-time=2025-02-19T08:00:28.818+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:28.818+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:28.822+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=3538958 error="driver: bad connection"
-time=2025-02-19T08:00:28.822+09:00 level=ERROR msg=Connector.Connect duration=3840000 error="driver: bad connection"
-time=2025-02-19T08:00:28.822+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:28.822+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:28.824+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=1788291 error="driver: bad connection"
-time=2025-02-19T08:00:28.824+09:00 level=ERROR msg=Connector.Connect duration=1896500 error="driver: bad connection"
-time=2025-02-19T08:00:28.824+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:28.824+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:28.826+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=1873500 error="driver: bad connection"
-time=2025-02-19T08:00:28.826+09:00 level=ERROR msg=Connector.Connect duration=2006584 error="driver: bad connection"
-time=2025-02-19T08:00:30.827+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:30.828+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:30.831+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=3473083 error="driver: bad connection"
-time=2025-02-19T08:00:30.831+09:00 level=ERROR msg=Connector.Connect duration=3678583 error="driver: bad connection"
-time=2025-02-19T08:00:30.831+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:30.831+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:30.834+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=2660709 error="driver: bad connection"
-time=2025-02-19T08:00:30.834+09:00 level=ERROR msg=Connector.Connect duration=2791667 error="driver: bad connection"
-time=2025-02-19T08:00:30.834+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:30.834+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:30.837+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=2155000 error="driver: bad connection"
-time=2025-02-19T08:00:30.837+09:00 level=ERROR msg=Connector.Connect duration=2359208 error="driver: bad connection"
-time=2025-02-19T08:00:32.838+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:32.840+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:32.844+09:00 level=INFO msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=4177250
-time=2025-02-19T08:00:32.845+09:00 level=INFO msg=Connector.Connect duration=4341834
-time=2025-02-19T08:00:32.845+09:00 level=VERBOSE msg=Conn.Ping conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:32.846+09:00 level=TRACE msg=Conn.Ping conn_id=EPx4leE8uxz3MhjW duration=1086542
-time=2025-02-19T08:00:32.846+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:32.846+09:00 level=TRACE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW duration=12417
-time=2025-02-19T08:00:32.846+09:00 level=DEBUG msg=Conn.ExecContext conn_id=EPx4leE8uxz3MhjW query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-19T08:00:32.862+09:00 level=INFO msg=Conn.ExecContext conn_id=EPx4leE8uxz3MhjW query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=15864250
-time=2025-02-19T08:00:32.862+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:32.862+09:00 level=TRACE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW duration=7500
-time=2025-02-19T08:00:32.862+09:00 level=VERBOSE msg=Conn.Ping conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:32.863+09:00 level=TRACE msg=Conn.Ping conn_id=EPx4leE8uxz3MhjW duration=794292
-time=2025-02-19T08:00:32.863+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:32.863+09:00 level=TRACE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW duration=1500
-time=2025-02-19T08:00:32.863+09:00 level=DEBUG msg=Conn.BeginTx conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:32.863+09:00 level=INFO msg=Conn.BeginTx conn_id=EPx4leE8uxz3MhjW duration=623625 tx_id=KjQ6rbW83PozzZoJ
-time=2025-02-19T08:00:32.863+09:00 level=DEBUG msg=Conn.ExecContext conn_id=EPx4leE8uxz3MhjW query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-19T08:00:32.863+09:00 level=INFO msg=Conn.ExecContext conn_id=EPx4leE8uxz3MhjW query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=792 skip=true
-time=2025-02-19T08:00:32.863+09:00 level=DEBUG msg=Conn.PrepareContext conn_id=EPx4leE8uxz3MhjW query="INSERT INTO test1 (id, name) VALUES (?, ?)"
-time=2025-02-19T08:00:32.870+09:00 level=INFO msg=Conn.PrepareContext conn_id=EPx4leE8uxz3MhjW query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=6660625 stmt_id=rzauFKrDM3kd7_wN
-time=2025-02-19T08:00:32.870+09:00 level=DEBUG msg=Stmt.ExecContext conn_id=EPx4leE8uxz3MhjW stmt_id=rzauFKrDM3kd7_wN args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-19T08:00:32.871+09:00 level=INFO msg=Stmt.ExecContext conn_id=EPx4leE8uxz3MhjW stmt_id=rzauFKrDM3kd7_wN args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=762208
-time=2025-02-19T08:00:32.871+09:00 level=DEBUG msg=Stmt.Close conn_id=EPx4leE8uxz3MhjW stmt_id=rzauFKrDM3kd7_wN
-time=2025-02-19T08:00:32.871+09:00 level=INFO msg=Stmt.Close conn_id=EPx4leE8uxz3MhjW stmt_id=rzauFKrDM3kd7_wN duration=11000
-time=2025-02-19T08:00:32.871+09:00 level=DEBUG msg=Tx.Commit conn_id=EPx4leE8uxz3MhjW tx_id=KjQ6rbW83PozzZoJ
-time=2025-02-19T08:00:32.873+09:00 level=INFO msg=Tx.Commit conn_id=EPx4leE8uxz3MhjW tx_id=KjQ6rbW83PozzZoJ duration=1954750
-time=2025-02-19T08:00:32.873+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:32.873+09:00 level=TRACE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW duration=4125
-time=2025-02-19T08:00:32.873+09:00 level=TRACE msg=Conn.QueryContext conn_id=EPx4leE8uxz3MhjW query="SELECT * FROM test1" args=[]
-time=2025-02-19T08:00:32.874+09:00 level=DEBUG msg=Conn.QueryContext conn_id=EPx4leE8uxz3MhjW query="SELECT * FROM test1" args=[] duration=470250
-time=2025-02-19T08:00:32.874+09:00 level=TRACE msg=Rows.Next conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:32.874+09:00 level=DEBUG msg=Rows.Next conn_id=EPx4leE8uxz3MhjW duration=30208 eof=false
-time=2025-02-19T08:00:32.874+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-19T08:00:32.874+09:00 level=TRACE msg=Rows.Next conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:32.874+09:00 level=DEBUG msg=Rows.Next conn_id=EPx4leE8uxz3MhjW duration=125 eof=true
-time=2025-02-19T08:00:32.874+09:00 level=TRACE msg=Rows.Close conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:32.874+09:00 level=DEBUG msg=Rows.Close conn_id=EPx4leE8uxz3MhjW duration=666
-time=2025-02-19T08:00:32.874+09:00 level=DEBUG msg=Conn.Close conn_id=EPx4leE8uxz3MhjW
-time=2025-02-19T08:00:32.874+09:00 level=INFO msg=Conn.Close conn_id=EPx4leE8uxz3MhjW duration=29208
+time=2025-02-19T08:25:14.804+09:00 level=DEBUG msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1
+time=2025-02-19T08:25:14.805+09:00 level=DEBUG msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1
+time=2025-02-19T08:25:14.805+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=3250 conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:14.805+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=185541
+time=2025-02-19T08:25:14.805+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:14.805+09:00 level=DEBUG msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:14.808+09:00 level=ERROR msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ duration=3073750 error="driver: bad connection"
+time=2025-02-19T08:25:14.808+09:00 level=ERROR msg=Connector.Connect duration=3108791 error="driver: bad connection"
+time=2025-02-19T08:25:14.808+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:14.808+09:00 level=DEBUG msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:14.808+09:00 level=ERROR msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ duration=542333 error="driver: bad connection"
+time=2025-02-19T08:25:14.808+09:00 level=ERROR msg=Connector.Connect duration=559166 error="driver: bad connection"
+time=2025-02-19T08:25:14.808+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:14.808+09:00 level=DEBUG msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:14.809+09:00 level=ERROR msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ duration=497000 error="driver: bad connection"
+time=2025-02-19T08:25:14.809+09:00 level=ERROR msg=Connector.Connect duration=507250 error="driver: bad connection"
+time=2025-02-19T08:25:16.810+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:16.810+09:00 level=DEBUG msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:16.813+09:00 level=ERROR msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ duration=2465250 error="driver: bad connection"
+time=2025-02-19T08:25:16.813+09:00 level=ERROR msg=Connector.Connect duration=2670667 error="driver: bad connection"
+time=2025-02-19T08:25:16.813+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:16.813+09:00 level=DEBUG msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:16.814+09:00 level=ERROR msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ duration=1436375 error="driver: bad connection"
+time=2025-02-19T08:25:16.815+09:00 level=ERROR msg=Connector.Connect duration=1563333 error="driver: bad connection"
+time=2025-02-19T08:25:16.815+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:16.815+09:00 level=DEBUG msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:16.815+09:00 level=ERROR msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ duration=900250 error="driver: bad connection"
+time=2025-02-19T08:25:16.816+09:00 level=ERROR msg=Connector.Connect duration=978042 error="driver: bad connection"
+time=2025-02-19T08:25:18.817+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:18.817+09:00 level=DEBUG msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:18.819+09:00 level=ERROR msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ duration=2300125 error="driver: bad connection"
+time=2025-02-19T08:25:18.819+09:00 level=ERROR msg=Connector.Connect duration=2415375 error="driver: bad connection"
+time=2025-02-19T08:25:18.819+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:18.819+09:00 level=DEBUG msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:18.820+09:00 level=ERROR msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ duration=1187042 error="driver: bad connection"
+time=2025-02-19T08:25:18.821+09:00 level=ERROR msg=Connector.Connect duration=1267417 error="driver: bad connection"
+time=2025-02-19T08:25:18.821+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:18.821+09:00 level=DEBUG msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:18.822+09:00 level=ERROR msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ duration=1109000 error="driver: bad connection"
+time=2025-02-19T08:25:18.822+09:00 level=ERROR msg=Connector.Connect duration=1237666 error="driver: bad connection"
+time=2025-02-19T08:25:20.823+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:25:20.823+09:00 level=DEBUG msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:20.827+09:00 level=INFO msg=Connector.Connect conn_id=SU8sW4BPEzVZjdTJ duration=4345958
+time=2025-02-19T08:25:20.827+09:00 level=INFO msg=Connector.Connect duration=4394167
+time=2025-02-19T08:25:20.827+09:00 level=VERBOSE msg=Conn.Ping conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:20.828+09:00 level=TRACE msg=Conn.Ping conn_id=SU8sW4BPEzVZjdTJ duration=461959
+time=2025-02-19T08:25:20.828+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:20.828+09:00 level=TRACE msg=Conn.ResetSession conn_id=SU8sW4BPEzVZjdTJ duration=3250
+time=2025-02-19T08:25:20.828+09:00 level=DEBUG msg=Conn.ExecContext conn_id=SU8sW4BPEzVZjdTJ query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:25:20.842+09:00 level=INFO msg=Conn.ExecContext conn_id=SU8sW4BPEzVZjdTJ query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=13984875
+time=2025-02-19T08:25:20.842+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:20.842+09:00 level=TRACE msg=Conn.ResetSession conn_id=SU8sW4BPEzVZjdTJ duration=1500
+time=2025-02-19T08:25:20.842+09:00 level=VERBOSE msg=Conn.Ping conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:20.842+09:00 level=TRACE msg=Conn.Ping conn_id=SU8sW4BPEzVZjdTJ duration=439083
+time=2025-02-19T08:25:20.842+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:20.842+09:00 level=TRACE msg=Conn.ResetSession conn_id=SU8sW4BPEzVZjdTJ duration=1208
+time=2025-02-19T08:25:20.842+09:00 level=DEBUG msg=Conn.BeginTx conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:20.843+09:00 level=INFO msg=Conn.BeginTx conn_id=SU8sW4BPEzVZjdTJ duration=424916 tx_id=dIFS6F1jIefQfKX7
+time=2025-02-19T08:25:20.843+09:00 level=DEBUG msg=Conn.ExecContext conn_id=SU8sW4BPEzVZjdTJ query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:25:20.843+09:00 level=INFO msg=Conn.ExecContext conn_id=SU8sW4BPEzVZjdTJ query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=459 skip=true
+time=2025-02-19T08:25:20.843+09:00 level=DEBUG msg=Conn.PrepareContext conn_id=SU8sW4BPEzVZjdTJ query="INSERT INTO test1 (id, name) VALUES (?, ?)"
+time=2025-02-19T08:25:20.845+09:00 level=INFO msg=Conn.PrepareContext conn_id=SU8sW4BPEzVZjdTJ query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=2325417 stmt_id=QINlqBJWBcghK4E1
+time=2025-02-19T08:25:20.845+09:00 level=DEBUG msg=Stmt.ExecContext conn_id=SU8sW4BPEzVZjdTJ stmt_id=QINlqBJWBcghK4E1 args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:25:20.846+09:00 level=INFO msg=Stmt.ExecContext conn_id=SU8sW4BPEzVZjdTJ stmt_id=QINlqBJWBcghK4E1 args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=503416
+time=2025-02-19T08:25:20.846+09:00 level=DEBUG msg=Stmt.Close conn_id=SU8sW4BPEzVZjdTJ stmt_id=QINlqBJWBcghK4E1
+time=2025-02-19T08:25:20.846+09:00 level=INFO msg=Stmt.Close conn_id=SU8sW4BPEzVZjdTJ stmt_id=QINlqBJWBcghK4E1 duration=7500
+time=2025-02-19T08:25:20.846+09:00 level=DEBUG msg=Tx.Commit conn_id=SU8sW4BPEzVZjdTJ tx_id=dIFS6F1jIefQfKX7
+time=2025-02-19T08:25:20.847+09:00 level=INFO msg=Tx.Commit conn_id=SU8sW4BPEzVZjdTJ tx_id=dIFS6F1jIefQfKX7 duration=1531459
+time=2025-02-19T08:25:20.847+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:20.847+09:00 level=TRACE msg=Conn.ResetSession conn_id=SU8sW4BPEzVZjdTJ duration=1416
+time=2025-02-19T08:25:20.847+09:00 level=TRACE msg=Conn.QueryContext conn_id=SU8sW4BPEzVZjdTJ query="SELECT * FROM test1" args=[]
+time=2025-02-19T08:25:20.848+09:00 level=DEBUG msg=Conn.QueryContext conn_id=SU8sW4BPEzVZjdTJ query="SELECT * FROM test1" args=[] duration=552500
+time=2025-02-19T08:25:20.848+09:00 level=TRACE msg=Rows.Next conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:20.848+09:00 level=DEBUG msg=Rows.Next conn_id=SU8sW4BPEzVZjdTJ duration=19875 eof=false
+time=2025-02-19T08:25:20.848+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:25:20.848+09:00 level=TRACE msg=Rows.Next conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:20.848+09:00 level=DEBUG msg=Rows.Next conn_id=SU8sW4BPEzVZjdTJ duration=250 eof=true
+time=2025-02-19T08:25:20.848+09:00 level=TRACE msg=Rows.Close conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:20.848+09:00 level=DEBUG msg=Rows.Close conn_id=SU8sW4BPEzVZjdTJ duration=333
+time=2025-02-19T08:25:20.848+09:00 level=DEBUG msg=Conn.Close conn_id=SU8sW4BPEzVZjdTJ
+time=2025-02-19T08:25:20.848+09:00 level=INFO msg=Conn.Close conn_id=SU8sW4BPEzVZjdTJ duration=20125

--- a/examples/logs-mysql/results/verbose-log.txt
+++ b/examples/logs-mysql/results/verbose-log.txt
@@ -1,94 +1,82 @@
 go run . verbose text
-time=2025-02-06T22:16:03.947+09:00 level=DEBUG msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1
-time=2025-02-06T22:16:03.948+09:00 level=DEBUG msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1
-time=2025-02-06T22:16:03.948+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=2667 conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:03.948+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=198292
-time=2025-02-06T22:16:03.948+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:03.948+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:03.950+09:00 level=ERROR msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=2588208 error="driver: bad connection"
-time=2025-02-06T22:16:03.951+09:00 level=ERROR msg=Connector.Connect duration=2842459 error="driver: bad connection"
-time=2025-02-06T22:16:03.951+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:03.951+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:03.952+09:00 level=ERROR msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=749375 error="driver: bad connection"
-time=2025-02-06T22:16:03.952+09:00 level=ERROR msg=Connector.Connect duration=801375 error="driver: bad connection"
-time=2025-02-06T22:16:03.952+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:03.952+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:03.956+09:00 level=ERROR msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=3892625 error="driver: bad connection"
-time=2025-02-06T22:16:03.956+09:00 level=ERROR msg=Connector.Connect duration=3960166 error="driver: bad connection"
-time=2025-02-06T22:16:05.957+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:05.957+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:05.962+09:00 level=ERROR msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=5108708 error="driver: bad connection"
-time=2025-02-06T22:16:05.962+09:00 level=ERROR msg=Connector.Connect duration=5298542 error="driver: bad connection"
-time=2025-02-06T22:16:05.962+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:05.962+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:05.964+09:00 level=ERROR msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=1822250 error="driver: bad connection"
-time=2025-02-06T22:16:05.964+09:00 level=ERROR msg=Connector.Connect duration=1915084 error="driver: bad connection"
-time=2025-02-06T22:16:05.964+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:05.964+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:05.967+09:00 level=ERROR msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=2885292 error="driver: bad connection"
-time=2025-02-06T22:16:05.967+09:00 level=ERROR msg=Connector.Connect duration=3012625 error="driver: bad connection"
-time=2025-02-06T22:16:07.968+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:07.968+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:07.970+09:00 level=ERROR msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=1390417 error="driver: bad connection"
-time=2025-02-06T22:16:07.970+09:00 level=ERROR msg=Connector.Connect duration=1457583 error="driver: bad connection"
-time=2025-02-06T22:16:07.970+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:07.970+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:07.971+09:00 level=ERROR msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=605625 error="driver: bad connection"
-time=2025-02-06T22:16:07.971+09:00 level=ERROR msg=Connector.Connect duration=643417 error="driver: bad connection"
-time=2025-02-06T22:16:07.971+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:07.971+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:07.971+09:00 level=ERROR msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=486125 error="driver: bad connection"
-time=2025-02-06T22:16:07.971+09:00 level=ERROR msg=Connector.Connect duration=529209 error="driver: bad connection"
-time=2025-02-06T22:16:09.972+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:09.972+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:09.976+09:00 level=ERROR msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=3553792 error="driver: bad connection"
-time=2025-02-06T22:16:09.976+09:00 level=ERROR msg=Connector.Connect duration=3722958 error="driver: bad connection"
-time=2025-02-06T22:16:09.976+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:09.976+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:09.978+09:00 level=ERROR msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=1875709 error="driver: bad connection"
-time=2025-02-06T22:16:09.978+09:00 level=ERROR msg=Connector.Connect duration=2007333 error="driver: bad connection"
-time=2025-02-06T22:16:09.978+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:09.978+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:09.980+09:00 level=ERROR msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=1761458 error="driver: bad connection"
-time=2025-02-06T22:16:09.980+09:00 level=ERROR msg=Connector.Connect duration=1890666 error="driver: bad connection"
-time=2025-02-06T22:16:11.981+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:16:11.982+09:00 level=DEBUG msg=Connector.Connect conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:11.988+09:00 level=INFO msg=Connector.Connect conn_id=DMCYnW16iT5bcAok duration=6734333
-time=2025-02-06T22:16:11.988+09:00 level=INFO msg=Connector.Connect duration=6880333
-time=2025-02-06T22:16:11.988+09:00 level=VERBOSE msg=Conn.Ping conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:11.989+09:00 level=TRACE msg=Conn.Ping conn_id=DMCYnW16iT5bcAok duration=797292
-time=2025-02-06T22:16:11.989+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:11.989+09:00 level=TRACE msg=Conn.ResetSession conn_id=DMCYnW16iT5bcAok duration=11959
-time=2025-02-06T22:16:11.989+09:00 level=DEBUG msg=Conn.ExecContext conn_id=DMCYnW16iT5bcAok query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-06T22:16:12.012+09:00 level=INFO msg=Conn.ExecContext conn_id=DMCYnW16iT5bcAok query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=22500375
-time=2025-02-06T22:16:12.012+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:12.012+09:00 level=TRACE msg=Conn.ResetSession conn_id=DMCYnW16iT5bcAok duration=9833
-time=2025-02-06T22:16:12.012+09:00 level=VERBOSE msg=Conn.Ping conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:12.013+09:00 level=TRACE msg=Conn.Ping conn_id=DMCYnW16iT5bcAok duration=552667
-time=2025-02-06T22:16:12.013+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:12.013+09:00 level=TRACE msg=Conn.ResetSession conn_id=DMCYnW16iT5bcAok duration=4125
-time=2025-02-06T22:16:12.013+09:00 level=DEBUG msg=Conn.BeginTx conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:12.013+09:00 level=INFO msg=Conn.BeginTx conn_id=DMCYnW16iT5bcAok duration=524833 tx_id=QRSlePxf0t7iYq9F
-time=2025-02-06T22:16:12.013+09:00 level=DEBUG msg=Conn.ExecContext conn_id=DMCYnW16iT5bcAok query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-06T22:16:12.014+09:00 level=INFO msg=Conn.ExecContext conn_id=DMCYnW16iT5bcAok query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=833 skip=true
-time=2025-02-06T22:16:12.014+09:00 level=DEBUG msg=Conn.PrepareContext conn_id=DMCYnW16iT5bcAok query="INSERT INTO test1 (id, name) VALUES (?, ?)"
-time=2025-02-06T22:16:12.017+09:00 level=INFO msg=Conn.PrepareContext conn_id=DMCYnW16iT5bcAok query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=3751042 stmt_id=MEi3GNre3M7WRF59
-time=2025-02-06T22:16:12.017+09:00 level=DEBUG msg=Stmt.ExecContext conn_id=DMCYnW16iT5bcAok stmt_id=MEi3GNre3M7WRF59 args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-06T22:16:12.018+09:00 level=INFO msg=Stmt.ExecContext conn_id=DMCYnW16iT5bcAok stmt_id=MEi3GNre3M7WRF59 args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=463375
-time=2025-02-06T22:16:12.018+09:00 level=DEBUG msg=Stmt.Close conn_id=DMCYnW16iT5bcAok stmt_id=MEi3GNre3M7WRF59
-time=2025-02-06T22:16:12.018+09:00 level=INFO msg=Stmt.Close conn_id=DMCYnW16iT5bcAok stmt_id=MEi3GNre3M7WRF59 duration=8542
-time=2025-02-06T22:16:12.018+09:00 level=DEBUG msg=Tx.Commit conn_id=DMCYnW16iT5bcAok tx_id=QRSlePxf0t7iYq9F
-time=2025-02-06T22:16:12.021+09:00 level=INFO msg=Tx.Commit conn_id=DMCYnW16iT5bcAok tx_id=QRSlePxf0t7iYq9F duration=2736375
-time=2025-02-06T22:16:12.021+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:12.021+09:00 level=TRACE msg=Conn.ResetSession conn_id=DMCYnW16iT5bcAok duration=1958
-time=2025-02-06T22:16:12.021+09:00 level=TRACE msg=Conn.QueryContext conn_id=DMCYnW16iT5bcAok query="SELECT * FROM test1" args=[]
-time=2025-02-06T22:16:12.021+09:00 level=DEBUG msg=Conn.QueryContext conn_id=DMCYnW16iT5bcAok query="SELECT * FROM test1" args=[] duration=433583
-time=2025-02-06T22:16:12.021+09:00 level=TRACE msg=Rows.Next conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:12.021+09:00 level=DEBUG msg=Rows.Next conn_id=DMCYnW16iT5bcAok duration=19667 eof=false
-time=2025-02-06T22:16:12.021+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-06T22:16:12.021+09:00 level=TRACE msg=Rows.Next conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:12.021+09:00 level=DEBUG msg=Rows.Next conn_id=DMCYnW16iT5bcAok duration=167 eof=true
-time=2025-02-06T22:16:12.021+09:00 level=TRACE msg=Rows.Close conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:12.021+09:00 level=DEBUG msg=Rows.Close conn_id=DMCYnW16iT5bcAok duration=667
-time=2025-02-06T22:16:12.021+09:00 level=DEBUG msg=Conn.Close conn_id=DMCYnW16iT5bcAok
-time=2025-02-06T22:16:12.021+09:00 level=INFO msg=Conn.Close conn_id=DMCYnW16iT5bcAok duration=28875
+time=2025-02-19T08:00:26.813+09:00 level=DEBUG msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1
+time=2025-02-19T08:00:26.813+09:00 level=DEBUG msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1
+time=2025-02-19T08:00:26.813+09:00 level=INFO msg=Driver.OpenConnector dsn=root@tcp(localhost:3306)/app1 duration=2667 conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:26.813+09:00 level=INFO msg=Open driver=mysql dsn=root@tcp(localhost:3306)/app1 duration=192750
+time=2025-02-19T08:00:26.813+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:26.813+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:26.816+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=2657084 error="driver: bad connection"
+time=2025-02-19T08:00:26.816+09:00 level=ERROR msg=Connector.Connect duration=2730625 error="driver: bad connection"
+time=2025-02-19T08:00:26.816+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:26.816+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:26.817+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=601208 error="driver: bad connection"
+time=2025-02-19T08:00:26.817+09:00 level=ERROR msg=Connector.Connect duration=634125 error="driver: bad connection"
+time=2025-02-19T08:00:26.817+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:26.817+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:26.817+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=479208 error="driver: bad connection"
+time=2025-02-19T08:00:26.817+09:00 level=ERROR msg=Connector.Connect duration=501750 error="driver: bad connection"
+time=2025-02-19T08:00:28.818+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:28.818+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:28.822+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=3538958 error="driver: bad connection"
+time=2025-02-19T08:00:28.822+09:00 level=ERROR msg=Connector.Connect duration=3840000 error="driver: bad connection"
+time=2025-02-19T08:00:28.822+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:28.822+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:28.824+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=1788291 error="driver: bad connection"
+time=2025-02-19T08:00:28.824+09:00 level=ERROR msg=Connector.Connect duration=1896500 error="driver: bad connection"
+time=2025-02-19T08:00:28.824+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:28.824+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:28.826+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=1873500 error="driver: bad connection"
+time=2025-02-19T08:00:28.826+09:00 level=ERROR msg=Connector.Connect duration=2006584 error="driver: bad connection"
+time=2025-02-19T08:00:30.827+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:30.828+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:30.831+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=3473083 error="driver: bad connection"
+time=2025-02-19T08:00:30.831+09:00 level=ERROR msg=Connector.Connect duration=3678583 error="driver: bad connection"
+time=2025-02-19T08:00:30.831+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:30.831+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:30.834+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=2660709 error="driver: bad connection"
+time=2025-02-19T08:00:30.834+09:00 level=ERROR msg=Connector.Connect duration=2791667 error="driver: bad connection"
+time=2025-02-19T08:00:30.834+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:30.834+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:30.837+09:00 level=ERROR msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=2155000 error="driver: bad connection"
+time=2025-02-19T08:00:30.837+09:00 level=ERROR msg=Connector.Connect duration=2359208 error="driver: bad connection"
+time=2025-02-19T08:00:32.838+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:32.840+09:00 level=DEBUG msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:32.844+09:00 level=INFO msg=Connector.Connect conn_id=EPx4leE8uxz3MhjW duration=4177250
+time=2025-02-19T08:00:32.845+09:00 level=INFO msg=Connector.Connect duration=4341834
+time=2025-02-19T08:00:32.845+09:00 level=VERBOSE msg=Conn.Ping conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:32.846+09:00 level=TRACE msg=Conn.Ping conn_id=EPx4leE8uxz3MhjW duration=1086542
+time=2025-02-19T08:00:32.846+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:32.846+09:00 level=TRACE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW duration=12417
+time=2025-02-19T08:00:32.846+09:00 level=DEBUG msg=Conn.ExecContext conn_id=EPx4leE8uxz3MhjW query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:00:32.862+09:00 level=INFO msg=Conn.ExecContext conn_id=EPx4leE8uxz3MhjW query="CREATE TABLE IF NOT EXISTS test1 (id INT PRIMARY KEY, name VARCHAR(255))" args=[] duration=15864250
+time=2025-02-19T08:00:32.862+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:32.862+09:00 level=TRACE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW duration=7500
+time=2025-02-19T08:00:32.862+09:00 level=VERBOSE msg=Conn.Ping conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:32.863+09:00 level=TRACE msg=Conn.Ping conn_id=EPx4leE8uxz3MhjW duration=794292
+time=2025-02-19T08:00:32.863+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:32.863+09:00 level=TRACE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW duration=1500
+time=2025-02-19T08:00:32.863+09:00 level=DEBUG msg=Conn.BeginTx conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:32.863+09:00 level=INFO msg=Conn.BeginTx conn_id=EPx4leE8uxz3MhjW duration=623625 tx_id=KjQ6rbW83PozzZoJ
+time=2025-02-19T08:00:32.863+09:00 level=DEBUG msg=Conn.ExecContext conn_id=EPx4leE8uxz3MhjW query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:00:32.863+09:00 level=INFO msg=Conn.ExecContext conn_id=EPx4leE8uxz3MhjW query="INSERT INTO test1 (id, name) VALUES (?, ?)" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=792 skip=true
+time=2025-02-19T08:00:32.863+09:00 level=DEBUG msg=Conn.PrepareContext conn_id=EPx4leE8uxz3MhjW query="INSERT INTO test1 (id, name) VALUES (?, ?)"
+time=2025-02-19T08:00:32.870+09:00 level=INFO msg=Conn.PrepareContext conn_id=EPx4leE8uxz3MhjW query="INSERT INTO test1 (id, name) VALUES (?, ?)" duration=6660625 stmt_id=rzauFKrDM3kd7_wN
+time=2025-02-19T08:00:32.870+09:00 level=DEBUG msg=Stmt.ExecContext conn_id=EPx4leE8uxz3MhjW stmt_id=rzauFKrDM3kd7_wN args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:00:32.871+09:00 level=INFO msg=Stmt.ExecContext conn_id=EPx4leE8uxz3MhjW stmt_id=rzauFKrDM3kd7_wN args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=762208
+time=2025-02-19T08:00:32.871+09:00 level=DEBUG msg=Stmt.Close conn_id=EPx4leE8uxz3MhjW stmt_id=rzauFKrDM3kd7_wN
+time=2025-02-19T08:00:32.871+09:00 level=INFO msg=Stmt.Close conn_id=EPx4leE8uxz3MhjW stmt_id=rzauFKrDM3kd7_wN duration=11000
+time=2025-02-19T08:00:32.871+09:00 level=DEBUG msg=Tx.Commit conn_id=EPx4leE8uxz3MhjW tx_id=KjQ6rbW83PozzZoJ
+time=2025-02-19T08:00:32.873+09:00 level=INFO msg=Tx.Commit conn_id=EPx4leE8uxz3MhjW tx_id=KjQ6rbW83PozzZoJ duration=1954750
+time=2025-02-19T08:00:32.873+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:32.873+09:00 level=TRACE msg=Conn.ResetSession conn_id=EPx4leE8uxz3MhjW duration=4125
+time=2025-02-19T08:00:32.873+09:00 level=TRACE msg=Conn.QueryContext conn_id=EPx4leE8uxz3MhjW query="SELECT * FROM test1" args=[]
+time=2025-02-19T08:00:32.874+09:00 level=DEBUG msg=Conn.QueryContext conn_id=EPx4leE8uxz3MhjW query="SELECT * FROM test1" args=[] duration=470250
+time=2025-02-19T08:00:32.874+09:00 level=TRACE msg=Rows.Next conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:32.874+09:00 level=DEBUG msg=Rows.Next conn_id=EPx4leE8uxz3MhjW duration=30208 eof=false
+time=2025-02-19T08:00:32.874+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:00:32.874+09:00 level=TRACE msg=Rows.Next conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:32.874+09:00 level=DEBUG msg=Rows.Next conn_id=EPx4leE8uxz3MhjW duration=125 eof=true
+time=2025-02-19T08:00:32.874+09:00 level=TRACE msg=Rows.Close conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:32.874+09:00 level=DEBUG msg=Rows.Close conn_id=EPx4leE8uxz3MhjW duration=666
+time=2025-02-19T08:00:32.874+09:00 level=DEBUG msg=Conn.Close conn_id=EPx4leE8uxz3MhjW
+time=2025-02-19T08:00:32.874+09:00 level=INFO msg=Conn.Close conn_id=EPx4leE8uxz3MhjW duration=29208

--- a/examples/logs-postgres/main.go
+++ b/examples/logs-postgres/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -14,26 +15,14 @@ import (
 )
 
 func main() {
-	var logLevel sqlslog.Level
-	if slices.Contains(os.Args, "debug") {
-		logLevel = sqlslog.LevelDebug
-	} else if slices.Contains(os.Args, "trace") {
-		logLevel = sqlslog.LevelTrace
-	} else if slices.Contains(os.Args, "verbose") {
-		logLevel = sqlslog.LevelVerbose
-	} else {
-		logLevel = sqlslog.LevelInfo
-	}
-	opts := &slog.HandlerOptions{Level: logLevel}
+	logLevel := sqlslog.ParseLevelWithDefault(os.Args[1], sqlslog.LevelInfo)
 
-	var handler slog.Handler
+	var handlerFunc func(io.Writer, *slog.HandlerOptions) slog.Handler
 	if slices.Contains(os.Args, "json") {
-		handler = sqlslog.NewJSONHandler(os.Stdout, opts)
+		handlerFunc = sqlslog.NewJSONHandler
 	} else {
-		handler = sqlslog.NewTextHandler(os.Stdout, opts)
+		handlerFunc = sqlslog.NewTextHandler
 	}
-	logger := slog.New(handler)
-
 	dbName := "app1"
 	dbPort := 5432
 	dsn := fmt.Sprintf("host=127.0.0.1 port=%d user=root password=password dbname=%s sslmode=disable", dbPort, dbName)
@@ -52,8 +41,9 @@ func main() {
 	ctx := context.Background()
 
 	// Open a database
-	db, err := sqlslog.Open(ctx, "postgres", dsn,
-		sqlslog.Logger(logger),
+	db, logger, err := sqlslog.Open(ctx, "postgres", dsn,
+		sqlslog.LogLevel(logLevel),
+		sqlslog.HandlerFunc(handlerFunc),
 		sqlslog.ConnQueryContext(func(o *sqlslog.StepOptions) {
 			o.SetLevel(sqlslog.LevelDebug)
 		}),

--- a/examples/logs-postgres/results/debug-log.txt
+++ b/examples/logs-postgres/results/debug-log.txt
@@ -1,26 +1,26 @@
 go run . debug text
-time=2025-02-06T22:15:30.191+09:00 level=DEBUG msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-06T22:15:30.191+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=54166
-time=2025-02-06T22:15:30.191+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:30.191+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-06T22:15:30.192+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=786625 error=EOF
-time=2025-02-06T22:15:30.192+09:00 level=ERROR msg=Connector.Connect duration=831917 error=EOF
-time=2025-02-06T22:15:32.193+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:32.193+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-06T22:15:32.207+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=13303917 conn_id=8RmY_HUYNBKSsOS_
-time=2025-02-06T22:15:32.207+09:00 level=INFO msg=Connector.Connect duration=13537042
-time=2025-02-06T22:15:32.208+09:00 level=DEBUG msg=Conn.ExecContext conn_id=8RmY_HUYNBKSsOS_ query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-06T22:15:32.212+09:00 level=INFO msg=Conn.ExecContext conn_id=8RmY_HUYNBKSsOS_ query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=4431834
-time=2025-02-06T22:15:32.213+09:00 level=DEBUG msg=Conn.BeginTx conn_id=8RmY_HUYNBKSsOS_
-time=2025-02-06T22:15:32.214+09:00 level=INFO msg=Conn.BeginTx conn_id=8RmY_HUYNBKSsOS_ duration=760709 tx_id=sFgVQPH0Ld7u3L8v
-time=2025-02-06T22:15:32.214+09:00 level=DEBUG msg=Conn.ExecContext conn_id=8RmY_HUYNBKSsOS_ query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-06T22:15:32.216+09:00 level=INFO msg=Conn.ExecContext conn_id=8RmY_HUYNBKSsOS_ query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1936166
-time=2025-02-06T22:15:32.216+09:00 level=DEBUG msg=Tx.Commit conn_id=8RmY_HUYNBKSsOS_ tx_id=sFgVQPH0Ld7u3L8v
-time=2025-02-06T22:15:32.218+09:00 level=INFO msg=Tx.Commit conn_id=8RmY_HUYNBKSsOS_ tx_id=sFgVQPH0Ld7u3L8v duration=1522083
-time=2025-02-06T22:15:32.219+09:00 level=DEBUG msg=Conn.QueryContext conn_id=8RmY_HUYNBKSsOS_ query="SELECT * FROM test1" args=[] duration=1043666
-time=2025-02-06T22:15:32.219+09:00 level=DEBUG msg=Rows.Next conn_id=8RmY_HUYNBKSsOS_ duration=3708 eof=false
-time=2025-02-06T22:15:32.219+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-06T22:15:32.219+09:00 level=DEBUG msg=Rows.Next conn_id=8RmY_HUYNBKSsOS_ duration=1708 eof=true
-time=2025-02-06T22:15:32.219+09:00 level=DEBUG msg=Rows.Close conn_id=8RmY_HUYNBKSsOS_ duration=583
-time=2025-02-06T22:15:32.219+09:00 level=DEBUG msg=Conn.Close conn_id=8RmY_HUYNBKSsOS_
-time=2025-02-06T22:15:32.219+09:00 level=INFO msg=Conn.Close conn_id=8RmY_HUYNBKSsOS_ duration=80291
+time=2025-02-19T07:59:55.490+09:00 level=DEBUG msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T07:59:55.490+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=70834
+time=2025-02-19T07:59:55.490+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T07:59:55.490+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T07:59:55.491+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=864959 error=EOF
+time=2025-02-19T07:59:55.491+09:00 level=ERROR msg=Connector.Connect duration=909000 error=EOF
+time=2025-02-19T07:59:57.492+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T07:59:57.492+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T07:59:57.505+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=13117417 conn_id=hOzyjw0zwydOBKVT
+time=2025-02-19T07:59:57.506+09:00 level=INFO msg=Connector.Connect duration=13414375
+time=2025-02-19T07:59:57.506+09:00 level=DEBUG msg=Conn.ExecContext conn_id=hOzyjw0zwydOBKVT query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T07:59:57.511+09:00 level=INFO msg=Conn.ExecContext conn_id=hOzyjw0zwydOBKVT query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=4425750
+time=2025-02-19T07:59:57.512+09:00 level=DEBUG msg=Conn.BeginTx conn_id=hOzyjw0zwydOBKVT
+time=2025-02-19T07:59:57.513+09:00 level=INFO msg=Conn.BeginTx conn_id=hOzyjw0zwydOBKVT duration=922834 tx_id=fBfLAIrONtgJOYGw
+time=2025-02-19T07:59:57.514+09:00 level=DEBUG msg=Conn.ExecContext conn_id=hOzyjw0zwydOBKVT query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T07:59:57.516+09:00 level=INFO msg=Conn.ExecContext conn_id=hOzyjw0zwydOBKVT query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=2355250
+time=2025-02-19T07:59:57.516+09:00 level=DEBUG msg=Tx.Commit conn_id=hOzyjw0zwydOBKVT tx_id=fBfLAIrONtgJOYGw
+time=2025-02-19T07:59:57.517+09:00 level=INFO msg=Tx.Commit conn_id=hOzyjw0zwydOBKVT tx_id=fBfLAIrONtgJOYGw duration=1325042
+time=2025-02-19T07:59:57.518+09:00 level=DEBUG msg=Conn.QueryContext conn_id=hOzyjw0zwydOBKVT query="SELECT * FROM test1" args=[] duration=712250
+time=2025-02-19T07:59:57.518+09:00 level=DEBUG msg=Rows.Next conn_id=hOzyjw0zwydOBKVT duration=3667 eof=false
+time=2025-02-19T07:59:57.518+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T07:59:57.518+09:00 level=DEBUG msg=Rows.Next conn_id=hOzyjw0zwydOBKVT duration=1750 eof=true
+time=2025-02-19T07:59:57.518+09:00 level=DEBUG msg=Rows.Close conn_id=hOzyjw0zwydOBKVT duration=458
+time=2025-02-19T07:59:57.519+09:00 level=DEBUG msg=Conn.Close conn_id=hOzyjw0zwydOBKVT
+time=2025-02-19T07:59:57.519+09:00 level=INFO msg=Conn.Close conn_id=hOzyjw0zwydOBKVT duration=94500

--- a/examples/logs-postgres/results/debug-log.txt
+++ b/examples/logs-postgres/results/debug-log.txt
@@ -1,26 +1,25 @@
-go run . debug text
-time=2025-02-19T07:59:55.490+09:00 level=DEBUG msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-19T07:59:55.490+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=70834
-time=2025-02-19T07:59:55.490+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T07:59:55.490+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-19T07:59:55.491+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=864959 error=EOF
-time=2025-02-19T07:59:55.491+09:00 level=ERROR msg=Connector.Connect duration=909000 error=EOF
-time=2025-02-19T07:59:57.492+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T07:59:57.492+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-19T07:59:57.505+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=13117417 conn_id=hOzyjw0zwydOBKVT
-time=2025-02-19T07:59:57.506+09:00 level=INFO msg=Connector.Connect duration=13414375
-time=2025-02-19T07:59:57.506+09:00 level=DEBUG msg=Conn.ExecContext conn_id=hOzyjw0zwydOBKVT query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-19T07:59:57.511+09:00 level=INFO msg=Conn.ExecContext conn_id=hOzyjw0zwydOBKVT query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=4425750
-time=2025-02-19T07:59:57.512+09:00 level=DEBUG msg=Conn.BeginTx conn_id=hOzyjw0zwydOBKVT
-time=2025-02-19T07:59:57.513+09:00 level=INFO msg=Conn.BeginTx conn_id=hOzyjw0zwydOBKVT duration=922834 tx_id=fBfLAIrONtgJOYGw
-time=2025-02-19T07:59:57.514+09:00 level=DEBUG msg=Conn.ExecContext conn_id=hOzyjw0zwydOBKVT query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-19T07:59:57.516+09:00 level=INFO msg=Conn.ExecContext conn_id=hOzyjw0zwydOBKVT query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=2355250
-time=2025-02-19T07:59:57.516+09:00 level=DEBUG msg=Tx.Commit conn_id=hOzyjw0zwydOBKVT tx_id=fBfLAIrONtgJOYGw
-time=2025-02-19T07:59:57.517+09:00 level=INFO msg=Tx.Commit conn_id=hOzyjw0zwydOBKVT tx_id=fBfLAIrONtgJOYGw duration=1325042
-time=2025-02-19T07:59:57.518+09:00 level=DEBUG msg=Conn.QueryContext conn_id=hOzyjw0zwydOBKVT query="SELECT * FROM test1" args=[] duration=712250
-time=2025-02-19T07:59:57.518+09:00 level=DEBUG msg=Rows.Next conn_id=hOzyjw0zwydOBKVT duration=3667 eof=false
-time=2025-02-19T07:59:57.518+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-19T07:59:57.518+09:00 level=DEBUG msg=Rows.Next conn_id=hOzyjw0zwydOBKVT duration=1750 eof=true
-time=2025-02-19T07:59:57.518+09:00 level=DEBUG msg=Rows.Close conn_id=hOzyjw0zwydOBKVT duration=458
-time=2025-02-19T07:59:57.519+09:00 level=DEBUG msg=Conn.Close conn_id=hOzyjw0zwydOBKVT
-time=2025-02-19T07:59:57.519+09:00 level=INFO msg=Conn.Close conn_id=hOzyjw0zwydOBKVT duration=94500
+time=2025-02-19T08:24:40.817+09:00 level=DEBUG msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:24:40.817+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=45083
+time=2025-02-19T08:24:40.817+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:24:40.817+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:24:40.818+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=954417 error=EOF
+time=2025-02-19T08:24:40.818+09:00 level=ERROR msg=Connector.Connect duration=1010458 error=EOF
+time=2025-02-19T08:24:42.819+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:24:42.820+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:24:42.833+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=12936959 conn_id=61Ugc1c8J8pgxWj8
+time=2025-02-19T08:24:42.833+09:00 level=INFO msg=Connector.Connect duration=13163125
+time=2025-02-19T08:24:42.833+09:00 level=DEBUG msg=Conn.ExecContext conn_id=61Ugc1c8J8pgxWj8 query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:24:42.838+09:00 level=INFO msg=Conn.ExecContext conn_id=61Ugc1c8J8pgxWj8 query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=4154125
+time=2025-02-19T08:24:42.838+09:00 level=DEBUG msg=Conn.BeginTx conn_id=61Ugc1c8J8pgxWj8
+time=2025-02-19T08:24:42.839+09:00 level=INFO msg=Conn.BeginTx conn_id=61Ugc1c8J8pgxWj8 duration=617709 tx_id=IalT4gLBWJxi4jbm
+time=2025-02-19T08:24:42.839+09:00 level=DEBUG msg=Conn.ExecContext conn_id=61Ugc1c8J8pgxWj8 query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:24:42.841+09:00 level=INFO msg=Conn.ExecContext conn_id=61Ugc1c8J8pgxWj8 query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1545375
+time=2025-02-19T08:24:42.841+09:00 level=DEBUG msg=Tx.Commit conn_id=61Ugc1c8J8pgxWj8 tx_id=IalT4gLBWJxi4jbm
+time=2025-02-19T08:24:42.842+09:00 level=INFO msg=Tx.Commit conn_id=61Ugc1c8J8pgxWj8 tx_id=IalT4gLBWJxi4jbm duration=990375
+time=2025-02-19T08:24:42.843+09:00 level=DEBUG msg=Conn.QueryContext conn_id=61Ugc1c8J8pgxWj8 query="SELECT * FROM test1" args=[] duration=631292
+time=2025-02-19T08:24:42.843+09:00 level=DEBUG msg=Rows.Next conn_id=61Ugc1c8J8pgxWj8 duration=2792 eof=false
+time=2025-02-19T08:24:42.843+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:24:42.843+09:00 level=DEBUG msg=Rows.Next conn_id=61Ugc1c8J8pgxWj8 duration=1209 eof=true
+time=2025-02-19T08:24:42.843+09:00 level=DEBUG msg=Rows.Close conn_id=61Ugc1c8J8pgxWj8 duration=250
+time=2025-02-19T08:24:42.843+09:00 level=DEBUG msg=Conn.Close conn_id=61Ugc1c8J8pgxWj8
+time=2025-02-19T08:24:42.843+09:00 level=INFO msg=Conn.Close conn_id=61Ugc1c8J8pgxWj8 duration=86708

--- a/examples/logs-postgres/results/info-log.txt
+++ b/examples/logs-postgres/results/info-log.txt
@@ -1,12 +1,11 @@
-go run . info text
-time=2025-02-19T07:59:52.698+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=69000
-time=2025-02-19T07:59:52.699+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=947250 error=EOF
-time=2025-02-19T07:59:52.699+09:00 level=ERROR msg=Connector.Connect duration=977542 error=EOF
-time=2025-02-19T07:59:54.708+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=8791000 conn_id=c2HCOIVlS2uLJo3M
-time=2025-02-19T07:59:54.708+09:00 level=INFO msg=Connector.Connect duration=8927792
-time=2025-02-19T07:59:54.714+09:00 level=INFO msg=Conn.ExecContext conn_id=c2HCOIVlS2uLJo3M query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=5181750
-time=2025-02-19T07:59:54.715+09:00 level=INFO msg=Conn.BeginTx conn_id=c2HCOIVlS2uLJo3M duration=412541 tx_id=Rp8Jd847q_Im_0fC
-time=2025-02-19T07:59:54.716+09:00 level=INFO msg=Conn.ExecContext conn_id=c2HCOIVlS2uLJo3M query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1189208
-time=2025-02-19T07:59:54.717+09:00 level=INFO msg=Tx.Commit conn_id=c2HCOIVlS2uLJo3M tx_id=Rp8Jd847q_Im_0fC duration=672542
-time=2025-02-19T07:59:54.717+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-19T07:59:54.717+09:00 level=INFO msg=Conn.Close conn_id=c2HCOIVlS2uLJo3M duration=22208
+time=2025-02-19T08:24:37.992+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=88917
+time=2025-02-19T08:24:37.994+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=1106584 error=EOF
+time=2025-02-19T08:24:37.994+09:00 level=ERROR msg=Connector.Connect duration=1177042 error=EOF
+time=2025-02-19T08:24:40.012+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=17772500 conn_id=VIccjsFjsJV7w21h
+time=2025-02-19T08:24:40.012+09:00 level=INFO msg=Connector.Connect duration=18083208
+time=2025-02-19T08:24:40.018+09:00 level=INFO msg=Conn.ExecContext conn_id=VIccjsFjsJV7w21h query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=4805208
+time=2025-02-19T08:24:40.019+09:00 level=INFO msg=Conn.BeginTx conn_id=VIccjsFjsJV7w21h duration=579334 tx_id=zPkm6sD1QPNBnYWX
+time=2025-02-19T08:24:40.021+09:00 level=INFO msg=Conn.ExecContext conn_id=VIccjsFjsJV7w21h query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1652042
+time=2025-02-19T08:24:40.023+09:00 level=INFO msg=Tx.Commit conn_id=VIccjsFjsJV7w21h tx_id=zPkm6sD1QPNBnYWX duration=1187791
+time=2025-02-19T08:24:40.023+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:24:40.023+09:00 level=INFO msg=Conn.Close conn_id=VIccjsFjsJV7w21h duration=66042

--- a/examples/logs-postgres/results/info-log.txt
+++ b/examples/logs-postgres/results/info-log.txt
@@ -1,12 +1,12 @@
 go run . info text
-time=2025-02-06T22:15:27.392+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=102000
-time=2025-02-06T22:15:27.394+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=822959 error=EOF
-time=2025-02-06T22:15:27.394+09:00 level=ERROR msg=Connector.Connect duration=859208 error=EOF
-time=2025-02-06T22:15:29.411+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=16854084 conn_id=5Z8wiX13YeXGtYjH
-time=2025-02-06T22:15:29.411+09:00 level=INFO msg=Connector.Connect duration=17112584
-time=2025-02-06T22:15:29.419+09:00 level=INFO msg=Conn.ExecContext conn_id=5Z8wiX13YeXGtYjH query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=5069750
-time=2025-02-06T22:15:29.420+09:00 level=INFO msg=Conn.BeginTx conn_id=5Z8wiX13YeXGtYjH duration=658083 tx_id=ritk44td4g2Hzuvn
-time=2025-02-06T22:15:29.423+09:00 level=INFO msg=Conn.ExecContext conn_id=5Z8wiX13YeXGtYjH query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=2012750
-time=2025-02-06T22:15:29.424+09:00 level=INFO msg=Tx.Commit conn_id=5Z8wiX13YeXGtYjH tx_id=ritk44td4g2Hzuvn duration=1352125
-time=2025-02-06T22:15:29.425+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-06T22:15:29.425+09:00 level=INFO msg=Conn.Close conn_id=5Z8wiX13YeXGtYjH duration=87958
+time=2025-02-19T07:59:52.698+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=69000
+time=2025-02-19T07:59:52.699+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=947250 error=EOF
+time=2025-02-19T07:59:52.699+09:00 level=ERROR msg=Connector.Connect duration=977542 error=EOF
+time=2025-02-19T07:59:54.708+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=8791000 conn_id=c2HCOIVlS2uLJo3M
+time=2025-02-19T07:59:54.708+09:00 level=INFO msg=Connector.Connect duration=8927792
+time=2025-02-19T07:59:54.714+09:00 level=INFO msg=Conn.ExecContext conn_id=c2HCOIVlS2uLJo3M query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=5181750
+time=2025-02-19T07:59:54.715+09:00 level=INFO msg=Conn.BeginTx conn_id=c2HCOIVlS2uLJo3M duration=412541 tx_id=Rp8Jd847q_Im_0fC
+time=2025-02-19T07:59:54.716+09:00 level=INFO msg=Conn.ExecContext conn_id=c2HCOIVlS2uLJo3M query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1189208
+time=2025-02-19T07:59:54.717+09:00 level=INFO msg=Tx.Commit conn_id=c2HCOIVlS2uLJo3M tx_id=Rp8Jd847q_Im_0fC duration=672542
+time=2025-02-19T07:59:54.717+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T07:59:54.717+09:00 level=INFO msg=Conn.Close conn_id=c2HCOIVlS2uLJo3M duration=22208

--- a/examples/logs-postgres/results/trace-log.txt
+++ b/examples/logs-postgres/results/trace-log.txt
@@ -1,36 +1,35 @@
-go run . trace text
-time=2025-02-19T07:59:58.298+09:00 level=DEBUG msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-19T07:59:58.298+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=48208
-time=2025-02-19T07:59:58.298+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T07:59:58.298+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-19T07:59:58.300+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=1113959 error=EOF
-time=2025-02-19T07:59:58.300+09:00 level=ERROR msg=Connector.Connect duration=1141125 error=EOF
-time=2025-02-19T08:00:00.301+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:00.301+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-19T08:00:00.316+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=14396500 conn_id=iBeGeVa3NzeqvNfe
-time=2025-02-19T08:00:00.316+09:00 level=INFO msg=Connector.Connect duration=14631666
-time=2025-02-19T08:00:00.316+09:00 level=TRACE msg=Conn.Ping conn_id=iBeGeVa3NzeqvNfe duration=397625
-time=2025-02-19T08:00:00.316+09:00 level=TRACE msg=Conn.ResetSession conn_id=iBeGeVa3NzeqvNfe duration=833
-time=2025-02-19T08:00:00.316+09:00 level=DEBUG msg=Conn.ExecContext conn_id=iBeGeVa3NzeqvNfe query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-19T08:00:00.321+09:00 level=INFO msg=Conn.ExecContext conn_id=iBeGeVa3NzeqvNfe query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=4218875
-time=2025-02-19T08:00:00.321+09:00 level=TRACE msg=Conn.ResetSession conn_id=iBeGeVa3NzeqvNfe duration=291
-time=2025-02-19T08:00:00.321+09:00 level=TRACE msg=Conn.Ping conn_id=iBeGeVa3NzeqvNfe duration=719042
-time=2025-02-19T08:00:00.321+09:00 level=TRACE msg=Conn.ResetSession conn_id=iBeGeVa3NzeqvNfe duration=125
-time=2025-02-19T08:00:00.321+09:00 level=DEBUG msg=Conn.BeginTx conn_id=iBeGeVa3NzeqvNfe
-time=2025-02-19T08:00:00.322+09:00 level=INFO msg=Conn.BeginTx conn_id=iBeGeVa3NzeqvNfe duration=545375 tx_id=navAzNhxaHCXTR6B
-time=2025-02-19T08:00:00.322+09:00 level=DEBUG msg=Conn.ExecContext conn_id=iBeGeVa3NzeqvNfe query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-19T08:00:00.324+09:00 level=INFO msg=Conn.ExecContext conn_id=iBeGeVa3NzeqvNfe query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1700125
-time=2025-02-19T08:00:00.324+09:00 level=DEBUG msg=Tx.Commit conn_id=iBeGeVa3NzeqvNfe tx_id=navAzNhxaHCXTR6B
-time=2025-02-19T08:00:00.325+09:00 level=INFO msg=Tx.Commit conn_id=iBeGeVa3NzeqvNfe tx_id=navAzNhxaHCXTR6B duration=991292
-time=2025-02-19T08:00:00.325+09:00 level=TRACE msg=Conn.ResetSession conn_id=iBeGeVa3NzeqvNfe duration=166
-time=2025-02-19T08:00:00.325+09:00 level=TRACE msg=Conn.QueryContext conn_id=iBeGeVa3NzeqvNfe query="SELECT * FROM test1" args=[]
-time=2025-02-19T08:00:00.326+09:00 level=DEBUG msg=Conn.QueryContext conn_id=iBeGeVa3NzeqvNfe query="SELECT * FROM test1" args=[] duration=610750
-time=2025-02-19T08:00:00.326+09:00 level=TRACE msg=Rows.Next conn_id=iBeGeVa3NzeqvNfe
-time=2025-02-19T08:00:00.326+09:00 level=DEBUG msg=Rows.Next conn_id=iBeGeVa3NzeqvNfe duration=3334 eof=false
-time=2025-02-19T08:00:00.326+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-19T08:00:00.326+09:00 level=TRACE msg=Rows.Next conn_id=iBeGeVa3NzeqvNfe
-time=2025-02-19T08:00:00.326+09:00 level=DEBUG msg=Rows.Next conn_id=iBeGeVa3NzeqvNfe duration=1250 eof=true
-time=2025-02-19T08:00:00.326+09:00 level=TRACE msg=Rows.Close conn_id=iBeGeVa3NzeqvNfe
-time=2025-02-19T08:00:00.326+09:00 level=DEBUG msg=Rows.Close conn_id=iBeGeVa3NzeqvNfe duration=542
-time=2025-02-19T08:00:00.326+09:00 level=DEBUG msg=Conn.Close conn_id=iBeGeVa3NzeqvNfe
-time=2025-02-19T08:00:00.326+09:00 level=INFO msg=Conn.Close conn_id=iBeGeVa3NzeqvNfe duration=40208
+time=2025-02-19T08:24:43.639+09:00 level=DEBUG msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:24:43.639+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=63250
+time=2025-02-19T08:24:43.639+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:24:43.639+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:24:43.640+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=822750 error=EOF
+time=2025-02-19T08:24:43.640+09:00 level=ERROR msg=Connector.Connect duration=869666 error=EOF
+time=2025-02-19T08:24:45.641+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:24:45.642+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:24:45.655+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=12805708 conn_id=_Y6P6RDoUv3By5sG
+time=2025-02-19T08:24:45.655+09:00 level=INFO msg=Connector.Connect duration=13109083
+time=2025-02-19T08:24:45.656+09:00 level=TRACE msg=Conn.Ping conn_id=_Y6P6RDoUv3By5sG duration=679542
+time=2025-02-19T08:24:45.656+09:00 level=TRACE msg=Conn.ResetSession conn_id=_Y6P6RDoUv3By5sG duration=708
+time=2025-02-19T08:24:45.656+09:00 level=DEBUG msg=Conn.ExecContext conn_id=_Y6P6RDoUv3By5sG query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:24:45.660+09:00 level=INFO msg=Conn.ExecContext conn_id=_Y6P6RDoUv3By5sG query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=4279750
+time=2025-02-19T08:24:45.660+09:00 level=TRACE msg=Conn.ResetSession conn_id=_Y6P6RDoUv3By5sG duration=334
+time=2025-02-19T08:24:45.661+09:00 level=TRACE msg=Conn.Ping conn_id=_Y6P6RDoUv3By5sG duration=648334
+time=2025-02-19T08:24:45.661+09:00 level=TRACE msg=Conn.ResetSession conn_id=_Y6P6RDoUv3By5sG duration=209
+time=2025-02-19T08:24:45.661+09:00 level=DEBUG msg=Conn.BeginTx conn_id=_Y6P6RDoUv3By5sG
+time=2025-02-19T08:24:45.661+09:00 level=INFO msg=Conn.BeginTx conn_id=_Y6P6RDoUv3By5sG duration=589750 tx_id=inB6TzL5WgAXGOs6
+time=2025-02-19T08:24:45.662+09:00 level=DEBUG msg=Conn.ExecContext conn_id=_Y6P6RDoUv3By5sG query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:24:45.663+09:00 level=INFO msg=Conn.ExecContext conn_id=_Y6P6RDoUv3By5sG query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1566625
+time=2025-02-19T08:24:45.663+09:00 level=DEBUG msg=Tx.Commit conn_id=_Y6P6RDoUv3By5sG tx_id=inB6TzL5WgAXGOs6
+time=2025-02-19T08:24:45.664+09:00 level=INFO msg=Tx.Commit conn_id=_Y6P6RDoUv3By5sG tx_id=inB6TzL5WgAXGOs6 duration=1046458
+time=2025-02-19T08:24:45.664+09:00 level=TRACE msg=Conn.ResetSession conn_id=_Y6P6RDoUv3By5sG duration=167
+time=2025-02-19T08:24:45.664+09:00 level=TRACE msg=Conn.QueryContext conn_id=_Y6P6RDoUv3By5sG query="SELECT * FROM test1" args=[]
+time=2025-02-19T08:24:45.665+09:00 level=DEBUG msg=Conn.QueryContext conn_id=_Y6P6RDoUv3By5sG query="SELECT * FROM test1" args=[] duration=587375
+time=2025-02-19T08:24:45.665+09:00 level=TRACE msg=Rows.Next conn_id=_Y6P6RDoUv3By5sG
+time=2025-02-19T08:24:45.665+09:00 level=DEBUG msg=Rows.Next conn_id=_Y6P6RDoUv3By5sG duration=3458 eof=false
+time=2025-02-19T08:24:45.665+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:24:45.665+09:00 level=TRACE msg=Rows.Next conn_id=_Y6P6RDoUv3By5sG
+time=2025-02-19T08:24:45.665+09:00 level=DEBUG msg=Rows.Next conn_id=_Y6P6RDoUv3By5sG duration=1125 eof=true
+time=2025-02-19T08:24:45.665+09:00 level=TRACE msg=Rows.Close conn_id=_Y6P6RDoUv3By5sG
+time=2025-02-19T08:24:45.665+09:00 level=DEBUG msg=Rows.Close conn_id=_Y6P6RDoUv3By5sG duration=416
+time=2025-02-19T08:24:45.665+09:00 level=DEBUG msg=Conn.Close conn_id=_Y6P6RDoUv3By5sG
+time=2025-02-19T08:24:45.665+09:00 level=INFO msg=Conn.Close conn_id=_Y6P6RDoUv3By5sG duration=53667

--- a/examples/logs-postgres/results/trace-log.txt
+++ b/examples/logs-postgres/results/trace-log.txt
@@ -1,36 +1,36 @@
 go run . trace text
-time=2025-02-06T22:15:32.970+09:00 level=DEBUG msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-06T22:15:32.970+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=52917
-time=2025-02-06T22:15:32.970+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:32.970+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-06T22:15:32.971+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=873583 error=EOF
-time=2025-02-06T22:15:32.971+09:00 level=ERROR msg=Connector.Connect duration=924667 error=EOF
-time=2025-02-06T22:15:34.972+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:34.973+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-06T22:15:34.990+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=16932084 conn_id=Z6URskyA1rX4yoDr
-time=2025-02-06T22:15:34.990+09:00 level=INFO msg=Connector.Connect duration=17334250
-time=2025-02-06T22:15:34.991+09:00 level=TRACE msg=Conn.Ping conn_id=Z6URskyA1rX4yoDr duration=1351000
-time=2025-02-06T22:15:34.991+09:00 level=TRACE msg=Conn.ResetSession conn_id=Z6URskyA1rX4yoDr duration=1208
-time=2025-02-06T22:15:34.991+09:00 level=DEBUG msg=Conn.ExecContext conn_id=Z6URskyA1rX4yoDr query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-06T22:15:34.997+09:00 level=INFO msg=Conn.ExecContext conn_id=Z6URskyA1rX4yoDr query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=5180167
-time=2025-02-06T22:15:34.997+09:00 level=TRACE msg=Conn.ResetSession conn_id=Z6URskyA1rX4yoDr duration=667
-time=2025-02-06T22:15:34.997+09:00 level=TRACE msg=Conn.Ping conn_id=Z6URskyA1rX4yoDr duration=733375
-time=2025-02-06T22:15:34.997+09:00 level=TRACE msg=Conn.ResetSession conn_id=Z6URskyA1rX4yoDr duration=291
-time=2025-02-06T22:15:34.998+09:00 level=DEBUG msg=Conn.BeginTx conn_id=Z6URskyA1rX4yoDr
-time=2025-02-06T22:15:34.998+09:00 level=INFO msg=Conn.BeginTx conn_id=Z6URskyA1rX4yoDr duration=839209 tx_id=JjI8VKrxGQfAry_p
-time=2025-02-06T22:15:34.999+09:00 level=DEBUG msg=Conn.ExecContext conn_id=Z6URskyA1rX4yoDr query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-06T22:15:35.002+09:00 level=INFO msg=Conn.ExecContext conn_id=Z6URskyA1rX4yoDr query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=2728250
-time=2025-02-06T22:15:35.002+09:00 level=DEBUG msg=Tx.Commit conn_id=Z6URskyA1rX4yoDr tx_id=JjI8VKrxGQfAry_p
-time=2025-02-06T22:15:35.003+09:00 level=INFO msg=Tx.Commit conn_id=Z6URskyA1rX4yoDr tx_id=JjI8VKrxGQfAry_p duration=1533125
-time=2025-02-06T22:15:35.003+09:00 level=TRACE msg=Conn.ResetSession conn_id=Z6URskyA1rX4yoDr duration=292
-time=2025-02-06T22:15:35.004+09:00 level=TRACE msg=Conn.QueryContext conn_id=Z6URskyA1rX4yoDr query="SELECT * FROM test1" args=[]
-time=2025-02-06T22:15:35.004+09:00 level=DEBUG msg=Conn.QueryContext conn_id=Z6URskyA1rX4yoDr query="SELECT * FROM test1" args=[] duration=793750
-time=2025-02-06T22:15:35.004+09:00 level=TRACE msg=Rows.Next conn_id=Z6URskyA1rX4yoDr
-time=2025-02-06T22:15:35.005+09:00 level=DEBUG msg=Rows.Next conn_id=Z6URskyA1rX4yoDr duration=3417 eof=false
-time=2025-02-06T22:15:35.005+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-06T22:15:35.005+09:00 level=TRACE msg=Rows.Next conn_id=Z6URskyA1rX4yoDr
-time=2025-02-06T22:15:35.005+09:00 level=DEBUG msg=Rows.Next conn_id=Z6URskyA1rX4yoDr duration=916 eof=true
-time=2025-02-06T22:15:35.005+09:00 level=TRACE msg=Rows.Close conn_id=Z6URskyA1rX4yoDr
-time=2025-02-06T22:15:35.005+09:00 level=DEBUG msg=Rows.Close conn_id=Z6URskyA1rX4yoDr duration=416
-time=2025-02-06T22:15:35.005+09:00 level=DEBUG msg=Conn.Close conn_id=Z6URskyA1rX4yoDr
-time=2025-02-06T22:15:35.005+09:00 level=INFO msg=Conn.Close conn_id=Z6URskyA1rX4yoDr duration=60625
+time=2025-02-19T07:59:58.298+09:00 level=DEBUG msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T07:59:58.298+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=48208
+time=2025-02-19T07:59:58.298+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T07:59:58.298+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T07:59:58.300+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=1113959 error=EOF
+time=2025-02-19T07:59:58.300+09:00 level=ERROR msg=Connector.Connect duration=1141125 error=EOF
+time=2025-02-19T08:00:00.301+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:00.301+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:00:00.316+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=14396500 conn_id=iBeGeVa3NzeqvNfe
+time=2025-02-19T08:00:00.316+09:00 level=INFO msg=Connector.Connect duration=14631666
+time=2025-02-19T08:00:00.316+09:00 level=TRACE msg=Conn.Ping conn_id=iBeGeVa3NzeqvNfe duration=397625
+time=2025-02-19T08:00:00.316+09:00 level=TRACE msg=Conn.ResetSession conn_id=iBeGeVa3NzeqvNfe duration=833
+time=2025-02-19T08:00:00.316+09:00 level=DEBUG msg=Conn.ExecContext conn_id=iBeGeVa3NzeqvNfe query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:00:00.321+09:00 level=INFO msg=Conn.ExecContext conn_id=iBeGeVa3NzeqvNfe query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=4218875
+time=2025-02-19T08:00:00.321+09:00 level=TRACE msg=Conn.ResetSession conn_id=iBeGeVa3NzeqvNfe duration=291
+time=2025-02-19T08:00:00.321+09:00 level=TRACE msg=Conn.Ping conn_id=iBeGeVa3NzeqvNfe duration=719042
+time=2025-02-19T08:00:00.321+09:00 level=TRACE msg=Conn.ResetSession conn_id=iBeGeVa3NzeqvNfe duration=125
+time=2025-02-19T08:00:00.321+09:00 level=DEBUG msg=Conn.BeginTx conn_id=iBeGeVa3NzeqvNfe
+time=2025-02-19T08:00:00.322+09:00 level=INFO msg=Conn.BeginTx conn_id=iBeGeVa3NzeqvNfe duration=545375 tx_id=navAzNhxaHCXTR6B
+time=2025-02-19T08:00:00.322+09:00 level=DEBUG msg=Conn.ExecContext conn_id=iBeGeVa3NzeqvNfe query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:00:00.324+09:00 level=INFO msg=Conn.ExecContext conn_id=iBeGeVa3NzeqvNfe query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1700125
+time=2025-02-19T08:00:00.324+09:00 level=DEBUG msg=Tx.Commit conn_id=iBeGeVa3NzeqvNfe tx_id=navAzNhxaHCXTR6B
+time=2025-02-19T08:00:00.325+09:00 level=INFO msg=Tx.Commit conn_id=iBeGeVa3NzeqvNfe tx_id=navAzNhxaHCXTR6B duration=991292
+time=2025-02-19T08:00:00.325+09:00 level=TRACE msg=Conn.ResetSession conn_id=iBeGeVa3NzeqvNfe duration=166
+time=2025-02-19T08:00:00.325+09:00 level=TRACE msg=Conn.QueryContext conn_id=iBeGeVa3NzeqvNfe query="SELECT * FROM test1" args=[]
+time=2025-02-19T08:00:00.326+09:00 level=DEBUG msg=Conn.QueryContext conn_id=iBeGeVa3NzeqvNfe query="SELECT * FROM test1" args=[] duration=610750
+time=2025-02-19T08:00:00.326+09:00 level=TRACE msg=Rows.Next conn_id=iBeGeVa3NzeqvNfe
+time=2025-02-19T08:00:00.326+09:00 level=DEBUG msg=Rows.Next conn_id=iBeGeVa3NzeqvNfe duration=3334 eof=false
+time=2025-02-19T08:00:00.326+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:00:00.326+09:00 level=TRACE msg=Rows.Next conn_id=iBeGeVa3NzeqvNfe
+time=2025-02-19T08:00:00.326+09:00 level=DEBUG msg=Rows.Next conn_id=iBeGeVa3NzeqvNfe duration=1250 eof=true
+time=2025-02-19T08:00:00.326+09:00 level=TRACE msg=Rows.Close conn_id=iBeGeVa3NzeqvNfe
+time=2025-02-19T08:00:00.326+09:00 level=DEBUG msg=Rows.Close conn_id=iBeGeVa3NzeqvNfe duration=542
+time=2025-02-19T08:00:00.326+09:00 level=DEBUG msg=Conn.Close conn_id=iBeGeVa3NzeqvNfe
+time=2025-02-19T08:00:00.326+09:00 level=INFO msg=Conn.Close conn_id=iBeGeVa3NzeqvNfe duration=40208

--- a/examples/logs-postgres/results/verbose-log.json
+++ b/examples/logs-postgres/results/verbose-log.json
@@ -1,0 +1,41 @@
+{"time":"2025-02-19T08:24:49.319057+09:00","level":"DEBUG","msg":"Open","driver":"postgres","dsn":"host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"}
+{"time":"2025-02-19T08:24:49.319365+09:00","level":"INFO","msg":"Open","driver":"postgres","dsn":"host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable","duration":51125}
+{"time":"2025-02-19T08:24:49.319385+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:24:49.31939+09:00","level":"DEBUG","msg":"Driver.Open","dsn":"host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"}
+{"time":"2025-02-19T08:24:49.320334+09:00","level":"ERROR","msg":"Driver.Open","dsn":"host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable","duration":933875,"error":"EOF"}
+{"time":"2025-02-19T08:24:49.320346+09:00","level":"ERROR","msg":"Connector.Connect","duration":955750,"error":"EOF"}
+{"time":"2025-02-19T08:24:51.32145+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:24:51.321759+09:00","level":"DEBUG","msg":"Driver.Open","dsn":"host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"}
+{"time":"2025-02-19T08:24:51.337042+09:00","level":"INFO","msg":"Driver.Open","dsn":"host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable","duration":15201500,"conn_id":"RxcviMP5EGYzSVUD"}
+{"time":"2025-02-19T08:24:51.337139+09:00","level":"INFO","msg":"Connector.Connect","duration":15421750}
+{"time":"2025-02-19T08:24:51.337199+09:00","level":"VERBOSE","msg":"Conn.Ping","conn_id":"RxcviMP5EGYzSVUD"}
+{"time":"2025-02-19T08:24:51.337884+09:00","level":"TRACE","msg":"Conn.Ping","conn_id":"RxcviMP5EGYzSVUD","duration":652000}
+{"time":"2025-02-19T08:24:51.33795+09:00","level":"VERBOSE","msg":"Conn.ResetSession","conn_id":"RxcviMP5EGYzSVUD"}
+{"time":"2025-02-19T08:24:51.337977+09:00","level":"TRACE","msg":"Conn.ResetSession","conn_id":"RxcviMP5EGYzSVUD","duration":917}
+{"time":"2025-02-19T08:24:51.338012+09:00","level":"DEBUG","msg":"Conn.ExecContext","conn_id":"RxcviMP5EGYzSVUD","query":"CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))","args":"[]"}
+{"time":"2025-02-19T08:24:51.342165+09:00","level":"INFO","msg":"Conn.ExecContext","conn_id":"RxcviMP5EGYzSVUD","query":"CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))","args":"[]","duration":4128250}
+{"time":"2025-02-19T08:24:51.342231+09:00","level":"VERBOSE","msg":"Conn.ResetSession","conn_id":"RxcviMP5EGYzSVUD"}
+{"time":"2025-02-19T08:24:51.34226+09:00","level":"TRACE","msg":"Conn.ResetSession","conn_id":"RxcviMP5EGYzSVUD","duration":500}
+{"time":"2025-02-19T08:24:51.342281+09:00","level":"VERBOSE","msg":"Conn.Ping","conn_id":"RxcviMP5EGYzSVUD"}
+{"time":"2025-02-19T08:24:51.342862+09:00","level":"TRACE","msg":"Conn.Ping","conn_id":"RxcviMP5EGYzSVUD","duration":558833}
+{"time":"2025-02-19T08:24:51.342922+09:00","level":"VERBOSE","msg":"Conn.ResetSession","conn_id":"RxcviMP5EGYzSVUD"}
+{"time":"2025-02-19T08:24:51.342951+09:00","level":"TRACE","msg":"Conn.ResetSession","conn_id":"RxcviMP5EGYzSVUD","duration":250}
+{"time":"2025-02-19T08:24:51.342979+09:00","level":"DEBUG","msg":"Conn.BeginTx","conn_id":"RxcviMP5EGYzSVUD"}
+{"time":"2025-02-19T08:24:51.343504+09:00","level":"INFO","msg":"Conn.BeginTx","conn_id":"RxcviMP5EGYzSVUD","duration":503167,"tx_id":"7qMOih0egKGVtZbB"}
+{"time":"2025-02-19T08:24:51.343633+09:00","level":"DEBUG","msg":"Conn.ExecContext","conn_id":"RxcviMP5EGYzSVUD","query":"INSERT INTO test1 (id, name) VALUES ($1,$2);","args":"[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"}
+{"time":"2025-02-19T08:24:51.345108+09:00","level":"INFO","msg":"Conn.ExecContext","conn_id":"RxcviMP5EGYzSVUD","query":"INSERT INTO test1 (id, name) VALUES ($1,$2);","args":"[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]","duration":1439166}
+{"time":"2025-02-19T08:24:51.345176+09:00","level":"DEBUG","msg":"Tx.Commit","conn_id":"RxcviMP5EGYzSVUD","tx_id":"7qMOih0egKGVtZbB"}
+{"time":"2025-02-19T08:24:51.346176+09:00","level":"INFO","msg":"Tx.Commit","conn_id":"RxcviMP5EGYzSVUD","tx_id":"7qMOih0egKGVtZbB","duration":962458}
+{"time":"2025-02-19T08:24:51.346279+09:00","level":"VERBOSE","msg":"Conn.ResetSession","conn_id":"RxcviMP5EGYzSVUD"}
+{"time":"2025-02-19T08:24:51.346303+09:00","level":"TRACE","msg":"Conn.ResetSession","conn_id":"RxcviMP5EGYzSVUD","duration":208}
+{"time":"2025-02-19T08:24:51.346326+09:00","level":"TRACE","msg":"Conn.QueryContext","conn_id":"RxcviMP5EGYzSVUD","query":"SELECT * FROM test1","args":"[]"}
+{"time":"2025-02-19T08:24:51.346978+09:00","level":"DEBUG","msg":"Conn.QueryContext","conn_id":"RxcviMP5EGYzSVUD","query":"SELECT * FROM test1","args":"[]","duration":633834}
+{"time":"2025-02-19T08:24:51.34704+09:00","level":"TRACE","msg":"Rows.Next","conn_id":"RxcviMP5EGYzSVUD"}
+{"time":"2025-02-19T08:24:51.347071+09:00","level":"DEBUG","msg":"Rows.Next","conn_id":"RxcviMP5EGYzSVUD","duration":3125,"eof":false}
+{"time":"2025-02-19T08:24:51.347136+09:00","level":"INFO","msg":"Record","id":1,"name":"Alice"}
+{"time":"2025-02-19T08:24:51.347161+09:00","level":"TRACE","msg":"Rows.Next","conn_id":"RxcviMP5EGYzSVUD"}
+{"time":"2025-02-19T08:24:51.347177+09:00","level":"DEBUG","msg":"Rows.Next","conn_id":"RxcviMP5EGYzSVUD","duration":1208,"eof":true}
+{"time":"2025-02-19T08:24:51.347195+09:00","level":"TRACE","msg":"Rows.Close","conn_id":"RxcviMP5EGYzSVUD"}
+{"time":"2025-02-19T08:24:51.347209+09:00","level":"DEBUG","msg":"Rows.Close","conn_id":"RxcviMP5EGYzSVUD","duration":209}
+{"time":"2025-02-19T08:24:51.347229+09:00","level":"DEBUG","msg":"Conn.Close","conn_id":"RxcviMP5EGYzSVUD"}
+{"time":"2025-02-19T08:24:51.34732+09:00","level":"INFO","msg":"Conn.Close","conn_id":"RxcviMP5EGYzSVUD","duration":74625}

--- a/examples/logs-postgres/results/verbose-log.txt
+++ b/examples/logs-postgres/results/verbose-log.txt
@@ -1,42 +1,42 @@
 go run . verbose text
-time=2025-02-06T22:15:35.798+09:00 level=DEBUG msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-06T22:15:35.798+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=63583
-time=2025-02-06T22:15:35.798+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:35.798+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-06T22:15:35.799+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=952708 error=EOF
-time=2025-02-06T22:15:35.799+09:00 level=ERROR msg=Connector.Connect duration=1032667 error=EOF
-time=2025-02-06T22:15:37.800+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:37.801+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-06T22:15:37.815+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=14775542 conn_id=oJiq87kjUzjvSze3
-time=2025-02-06T22:15:37.816+09:00 level=INFO msg=Connector.Connect duration=15134167
-time=2025-02-06T22:15:37.816+09:00 level=VERBOSE msg=Conn.Ping conn_id=oJiq87kjUzjvSze3
-time=2025-02-06T22:15:37.817+09:00 level=TRACE msg=Conn.Ping conn_id=oJiq87kjUzjvSze3 duration=1025750
-time=2025-02-06T22:15:37.817+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=oJiq87kjUzjvSze3
-time=2025-02-06T22:15:37.817+09:00 level=TRACE msg=Conn.ResetSession conn_id=oJiq87kjUzjvSze3 duration=1292
-time=2025-02-06T22:15:37.817+09:00 level=DEBUG msg=Conn.ExecContext conn_id=oJiq87kjUzjvSze3 query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-06T22:15:37.822+09:00 level=INFO msg=Conn.ExecContext conn_id=oJiq87kjUzjvSze3 query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=4726291
-time=2025-02-06T22:15:37.822+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=oJiq87kjUzjvSze3
-time=2025-02-06T22:15:37.822+09:00 level=TRACE msg=Conn.ResetSession conn_id=oJiq87kjUzjvSze3 duration=500
-time=2025-02-06T22:15:37.822+09:00 level=VERBOSE msg=Conn.Ping conn_id=oJiq87kjUzjvSze3
-time=2025-02-06T22:15:37.823+09:00 level=TRACE msg=Conn.Ping conn_id=oJiq87kjUzjvSze3 duration=1029584
-time=2025-02-06T22:15:37.823+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=oJiq87kjUzjvSze3
-time=2025-02-06T22:15:37.823+09:00 level=TRACE msg=Conn.ResetSession conn_id=oJiq87kjUzjvSze3 duration=334
-time=2025-02-06T22:15:37.823+09:00 level=DEBUG msg=Conn.BeginTx conn_id=oJiq87kjUzjvSze3
-time=2025-02-06T22:15:37.824+09:00 level=INFO msg=Conn.BeginTx conn_id=oJiq87kjUzjvSze3 duration=1122166 tx_id=ypP_X6IbdvecRKJC
-time=2025-02-06T22:15:37.824+09:00 level=DEBUG msg=Conn.ExecContext conn_id=oJiq87kjUzjvSze3 query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-06T22:15:37.826+09:00 level=INFO msg=Conn.ExecContext conn_id=oJiq87kjUzjvSze3 query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1967875
-time=2025-02-06T22:15:37.827+09:00 level=DEBUG msg=Tx.Commit conn_id=oJiq87kjUzjvSze3 tx_id=ypP_X6IbdvecRKJC
-time=2025-02-06T22:15:37.828+09:00 level=INFO msg=Tx.Commit conn_id=oJiq87kjUzjvSze3 tx_id=ypP_X6IbdvecRKJC duration=1388375
-time=2025-02-06T22:15:37.828+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=oJiq87kjUzjvSze3
-time=2025-02-06T22:15:37.828+09:00 level=TRACE msg=Conn.ResetSession conn_id=oJiq87kjUzjvSze3 duration=208
-time=2025-02-06T22:15:37.828+09:00 level=TRACE msg=Conn.QueryContext conn_id=oJiq87kjUzjvSze3 query="SELECT * FROM test1" args=[]
-time=2025-02-06T22:15:37.829+09:00 level=DEBUG msg=Conn.QueryContext conn_id=oJiq87kjUzjvSze3 query="SELECT * FROM test1" args=[] duration=900833
-time=2025-02-06T22:15:37.829+09:00 level=TRACE msg=Rows.Next conn_id=oJiq87kjUzjvSze3
-time=2025-02-06T22:15:37.829+09:00 level=DEBUG msg=Rows.Next conn_id=oJiq87kjUzjvSze3 duration=3166 eof=false
-time=2025-02-06T22:15:37.829+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-06T22:15:37.829+09:00 level=TRACE msg=Rows.Next conn_id=oJiq87kjUzjvSze3
-time=2025-02-06T22:15:37.829+09:00 level=DEBUG msg=Rows.Next conn_id=oJiq87kjUzjvSze3 duration=1375 eof=true
-time=2025-02-06T22:15:37.829+09:00 level=TRACE msg=Rows.Close conn_id=oJiq87kjUzjvSze3
-time=2025-02-06T22:15:37.829+09:00 level=DEBUG msg=Rows.Close conn_id=oJiq87kjUzjvSze3 duration=666
-time=2025-02-06T22:15:37.829+09:00 level=DEBUG msg=Conn.Close conn_id=oJiq87kjUzjvSze3
-time=2025-02-06T22:15:37.829+09:00 level=INFO msg=Conn.Close conn_id=oJiq87kjUzjvSze3 duration=75125
+time=2025-02-19T08:00:01.112+09:00 level=DEBUG msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:00:01.113+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=47958
+time=2025-02-19T08:00:01.113+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:01.113+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:00:01.113+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=769917 error=EOF
+time=2025-02-19T08:00:01.114+09:00 level=ERROR msg=Connector.Connect duration=795625 error=EOF
+time=2025-02-19T08:00:03.115+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:00:03.115+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:00:03.128+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=12730833 conn_id=K1fL_Z93omUpQw4a
+time=2025-02-19T08:00:03.128+09:00 level=INFO msg=Connector.Connect duration=12899208
+time=2025-02-19T08:00:03.128+09:00 level=VERBOSE msg=Conn.Ping conn_id=K1fL_Z93omUpQw4a
+time=2025-02-19T08:00:03.129+09:00 level=TRACE msg=Conn.Ping conn_id=K1fL_Z93omUpQw4a duration=671166
+time=2025-02-19T08:00:03.129+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a
+time=2025-02-19T08:00:03.129+09:00 level=TRACE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a duration=1000
+time=2025-02-19T08:00:03.129+09:00 level=DEBUG msg=Conn.ExecContext conn_id=K1fL_Z93omUpQw4a query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:00:03.133+09:00 level=INFO msg=Conn.ExecContext conn_id=K1fL_Z93omUpQw4a query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=4538375
+time=2025-02-19T08:00:03.133+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a
+time=2025-02-19T08:00:03.133+09:00 level=TRACE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a duration=500
+time=2025-02-19T08:00:03.133+09:00 level=VERBOSE msg=Conn.Ping conn_id=K1fL_Z93omUpQw4a
+time=2025-02-19T08:00:03.134+09:00 level=TRACE msg=Conn.Ping conn_id=K1fL_Z93omUpQw4a duration=629875
+time=2025-02-19T08:00:03.134+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a
+time=2025-02-19T08:00:03.134+09:00 level=TRACE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a duration=250
+time=2025-02-19T08:00:03.134+09:00 level=DEBUG msg=Conn.BeginTx conn_id=K1fL_Z93omUpQw4a
+time=2025-02-19T08:00:03.135+09:00 level=INFO msg=Conn.BeginTx conn_id=K1fL_Z93omUpQw4a duration=585167 tx_id=AxD8Ukri793klgOR
+time=2025-02-19T08:00:03.135+09:00 level=DEBUG msg=Conn.ExecContext conn_id=K1fL_Z93omUpQw4a query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:00:03.136+09:00 level=INFO msg=Conn.ExecContext conn_id=K1fL_Z93omUpQw4a query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1535416
+time=2025-02-19T08:00:03.137+09:00 level=DEBUG msg=Tx.Commit conn_id=K1fL_Z93omUpQw4a tx_id=AxD8Ukri793klgOR
+time=2025-02-19T08:00:03.138+09:00 level=INFO msg=Tx.Commit conn_id=K1fL_Z93omUpQw4a tx_id=AxD8Ukri793klgOR duration=971500
+time=2025-02-19T08:00:03.138+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a
+time=2025-02-19T08:00:03.138+09:00 level=TRACE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a duration=167
+time=2025-02-19T08:00:03.138+09:00 level=TRACE msg=Conn.QueryContext conn_id=K1fL_Z93omUpQw4a query="SELECT * FROM test1" args=[]
+time=2025-02-19T08:00:03.138+09:00 level=DEBUG msg=Conn.QueryContext conn_id=K1fL_Z93omUpQw4a query="SELECT * FROM test1" args=[] duration=586750
+time=2025-02-19T08:00:03.138+09:00 level=TRACE msg=Rows.Next conn_id=K1fL_Z93omUpQw4a
+time=2025-02-19T08:00:03.138+09:00 level=DEBUG msg=Rows.Next conn_id=K1fL_Z93omUpQw4a duration=3041 eof=false
+time=2025-02-19T08:00:03.138+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:00:03.138+09:00 level=TRACE msg=Rows.Next conn_id=K1fL_Z93omUpQw4a
+time=2025-02-19T08:00:03.138+09:00 level=DEBUG msg=Rows.Next conn_id=K1fL_Z93omUpQw4a duration=1042 eof=true
+time=2025-02-19T08:00:03.138+09:00 level=TRACE msg=Rows.Close conn_id=K1fL_Z93omUpQw4a
+time=2025-02-19T08:00:03.138+09:00 level=DEBUG msg=Rows.Close conn_id=K1fL_Z93omUpQw4a duration=209
+time=2025-02-19T08:00:03.138+09:00 level=DEBUG msg=Conn.Close conn_id=K1fL_Z93omUpQw4a
+time=2025-02-19T08:00:03.139+09:00 level=INFO msg=Conn.Close conn_id=K1fL_Z93omUpQw4a duration=46625

--- a/examples/logs-postgres/results/verbose-log.txt
+++ b/examples/logs-postgres/results/verbose-log.txt
@@ -1,42 +1,41 @@
-go run . verbose text
-time=2025-02-19T08:00:01.112+09:00 level=DEBUG msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-19T08:00:01.113+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=47958
-time=2025-02-19T08:00:01.113+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:01.113+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-19T08:00:01.113+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=769917 error=EOF
-time=2025-02-19T08:00:01.114+09:00 level=ERROR msg=Connector.Connect duration=795625 error=EOF
-time=2025-02-19T08:00:03.115+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T08:00:03.115+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
-time=2025-02-19T08:00:03.128+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=12730833 conn_id=K1fL_Z93omUpQw4a
-time=2025-02-19T08:00:03.128+09:00 level=INFO msg=Connector.Connect duration=12899208
-time=2025-02-19T08:00:03.128+09:00 level=VERBOSE msg=Conn.Ping conn_id=K1fL_Z93omUpQw4a
-time=2025-02-19T08:00:03.129+09:00 level=TRACE msg=Conn.Ping conn_id=K1fL_Z93omUpQw4a duration=671166
-time=2025-02-19T08:00:03.129+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a
-time=2025-02-19T08:00:03.129+09:00 level=TRACE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a duration=1000
-time=2025-02-19T08:00:03.129+09:00 level=DEBUG msg=Conn.ExecContext conn_id=K1fL_Z93omUpQw4a query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-19T08:00:03.133+09:00 level=INFO msg=Conn.ExecContext conn_id=K1fL_Z93omUpQw4a query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=4538375
-time=2025-02-19T08:00:03.133+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a
-time=2025-02-19T08:00:03.133+09:00 level=TRACE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a duration=500
-time=2025-02-19T08:00:03.133+09:00 level=VERBOSE msg=Conn.Ping conn_id=K1fL_Z93omUpQw4a
-time=2025-02-19T08:00:03.134+09:00 level=TRACE msg=Conn.Ping conn_id=K1fL_Z93omUpQw4a duration=629875
-time=2025-02-19T08:00:03.134+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a
-time=2025-02-19T08:00:03.134+09:00 level=TRACE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a duration=250
-time=2025-02-19T08:00:03.134+09:00 level=DEBUG msg=Conn.BeginTx conn_id=K1fL_Z93omUpQw4a
-time=2025-02-19T08:00:03.135+09:00 level=INFO msg=Conn.BeginTx conn_id=K1fL_Z93omUpQw4a duration=585167 tx_id=AxD8Ukri793klgOR
-time=2025-02-19T08:00:03.135+09:00 level=DEBUG msg=Conn.ExecContext conn_id=K1fL_Z93omUpQw4a query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
-time=2025-02-19T08:00:03.136+09:00 level=INFO msg=Conn.ExecContext conn_id=K1fL_Z93omUpQw4a query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1535416
-time=2025-02-19T08:00:03.137+09:00 level=DEBUG msg=Tx.Commit conn_id=K1fL_Z93omUpQw4a tx_id=AxD8Ukri793klgOR
-time=2025-02-19T08:00:03.138+09:00 level=INFO msg=Tx.Commit conn_id=K1fL_Z93omUpQw4a tx_id=AxD8Ukri793klgOR duration=971500
-time=2025-02-19T08:00:03.138+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a
-time=2025-02-19T08:00:03.138+09:00 level=TRACE msg=Conn.ResetSession conn_id=K1fL_Z93omUpQw4a duration=167
-time=2025-02-19T08:00:03.138+09:00 level=TRACE msg=Conn.QueryContext conn_id=K1fL_Z93omUpQw4a query="SELECT * FROM test1" args=[]
-time=2025-02-19T08:00:03.138+09:00 level=DEBUG msg=Conn.QueryContext conn_id=K1fL_Z93omUpQw4a query="SELECT * FROM test1" args=[] duration=586750
-time=2025-02-19T08:00:03.138+09:00 level=TRACE msg=Rows.Next conn_id=K1fL_Z93omUpQw4a
-time=2025-02-19T08:00:03.138+09:00 level=DEBUG msg=Rows.Next conn_id=K1fL_Z93omUpQw4a duration=3041 eof=false
-time=2025-02-19T08:00:03.138+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-19T08:00:03.138+09:00 level=TRACE msg=Rows.Next conn_id=K1fL_Z93omUpQw4a
-time=2025-02-19T08:00:03.138+09:00 level=DEBUG msg=Rows.Next conn_id=K1fL_Z93omUpQw4a duration=1042 eof=true
-time=2025-02-19T08:00:03.138+09:00 level=TRACE msg=Rows.Close conn_id=K1fL_Z93omUpQw4a
-time=2025-02-19T08:00:03.138+09:00 level=DEBUG msg=Rows.Close conn_id=K1fL_Z93omUpQw4a duration=209
-time=2025-02-19T08:00:03.138+09:00 level=DEBUG msg=Conn.Close conn_id=K1fL_Z93omUpQw4a
-time=2025-02-19T08:00:03.139+09:00 level=INFO msg=Conn.Close conn_id=K1fL_Z93omUpQw4a duration=46625
+time=2025-02-19T08:24:46.479+09:00 level=DEBUG msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:24:46.479+09:00 level=INFO msg=Open driver=postgres dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=67250
+time=2025-02-19T08:24:46.479+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:24:46.479+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:24:46.480+09:00 level=ERROR msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=1015500 error=EOF
+time=2025-02-19T08:24:46.480+09:00 level=ERROR msg=Connector.Connect duration=1076958 error=EOF
+time=2025-02-19T08:24:48.481+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:24:48.482+09:00 level=DEBUG msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable"
+time=2025-02-19T08:24:48.495+09:00 level=INFO msg=Driver.Open dsn="host=127.0.0.1 port=5432 user=root password=password dbname=app1 sslmode=disable" duration=13364584 conn_id=8Y6397a_miS2KVZ8
+time=2025-02-19T08:24:48.495+09:00 level=INFO msg=Connector.Connect duration=13645166
+time=2025-02-19T08:24:48.495+09:00 level=VERBOSE msg=Conn.Ping conn_id=8Y6397a_miS2KVZ8
+time=2025-02-19T08:24:48.496+09:00 level=TRACE msg=Conn.Ping conn_id=8Y6397a_miS2KVZ8 duration=741083
+time=2025-02-19T08:24:48.496+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=8Y6397a_miS2KVZ8
+time=2025-02-19T08:24:48.496+09:00 level=TRACE msg=Conn.ResetSession conn_id=8Y6397a_miS2KVZ8 duration=959
+time=2025-02-19T08:24:48.496+09:00 level=DEBUG msg=Conn.ExecContext conn_id=8Y6397a_miS2KVZ8 query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:24:48.500+09:00 level=INFO msg=Conn.ExecContext conn_id=8Y6397a_miS2KVZ8 query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=4228208
+time=2025-02-19T08:24:48.501+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=8Y6397a_miS2KVZ8
+time=2025-02-19T08:24:48.501+09:00 level=TRACE msg=Conn.ResetSession conn_id=8Y6397a_miS2KVZ8 duration=459
+time=2025-02-19T08:24:48.501+09:00 level=VERBOSE msg=Conn.Ping conn_id=8Y6397a_miS2KVZ8
+time=2025-02-19T08:24:48.501+09:00 level=TRACE msg=Conn.Ping conn_id=8Y6397a_miS2KVZ8 duration=686792
+time=2025-02-19T08:24:48.501+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=8Y6397a_miS2KVZ8
+time=2025-02-19T08:24:48.501+09:00 level=TRACE msg=Conn.ResetSession conn_id=8Y6397a_miS2KVZ8 duration=500
+time=2025-02-19T08:24:48.501+09:00 level=DEBUG msg=Conn.BeginTx conn_id=8Y6397a_miS2KVZ8
+time=2025-02-19T08:24:48.502+09:00 level=INFO msg=Conn.BeginTx conn_id=8Y6397a_miS2KVZ8 duration=603250 tx_id=m7rRA81L0yMj7oAg
+time=2025-02-19T08:24:48.502+09:00 level=DEBUG msg=Conn.ExecContext conn_id=8Y6397a_miS2KVZ8 query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]"
+time=2025-02-19T08:24:48.504+09:00 level=INFO msg=Conn.ExecContext conn_id=8Y6397a_miS2KVZ8 query="INSERT INTO test1 (id, name) VALUES ($1,$2);" args="[{Name: Ordinal:1 Value:1} {Name: Ordinal:2 Value:Alice}]" duration=1624125
+time=2025-02-19T08:24:48.504+09:00 level=DEBUG msg=Tx.Commit conn_id=8Y6397a_miS2KVZ8 tx_id=m7rRA81L0yMj7oAg
+time=2025-02-19T08:24:48.505+09:00 level=INFO msg=Tx.Commit conn_id=8Y6397a_miS2KVZ8 tx_id=m7rRA81L0yMj7oAg duration=1068542
+time=2025-02-19T08:24:48.505+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=8Y6397a_miS2KVZ8
+time=2025-02-19T08:24:48.505+09:00 level=TRACE msg=Conn.ResetSession conn_id=8Y6397a_miS2KVZ8 duration=166
+time=2025-02-19T08:24:48.505+09:00 level=TRACE msg=Conn.QueryContext conn_id=8Y6397a_miS2KVZ8 query="SELECT * FROM test1" args=[]
+time=2025-02-19T08:24:48.506+09:00 level=DEBUG msg=Conn.QueryContext conn_id=8Y6397a_miS2KVZ8 query="SELECT * FROM test1" args=[] duration=711459
+time=2025-02-19T08:24:48.506+09:00 level=TRACE msg=Rows.Next conn_id=8Y6397a_miS2KVZ8
+time=2025-02-19T08:24:48.506+09:00 level=DEBUG msg=Rows.Next conn_id=8Y6397a_miS2KVZ8 duration=3625 eof=false
+time=2025-02-19T08:24:48.506+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:24:48.506+09:00 level=TRACE msg=Rows.Next conn_id=8Y6397a_miS2KVZ8
+time=2025-02-19T08:24:48.506+09:00 level=DEBUG msg=Rows.Next conn_id=8Y6397a_miS2KVZ8 duration=1417 eof=true
+time=2025-02-19T08:24:48.506+09:00 level=TRACE msg=Rows.Close conn_id=8Y6397a_miS2KVZ8
+time=2025-02-19T08:24:48.506+09:00 level=DEBUG msg=Rows.Close conn_id=8Y6397a_miS2KVZ8 duration=417
+time=2025-02-19T08:24:48.506+09:00 level=DEBUG msg=Conn.Close conn_id=8Y6397a_miS2KVZ8
+time=2025-02-19T08:24:48.506+09:00 level=INFO msg=Conn.Close conn_id=8Y6397a_miS2KVZ8 duration=75583

--- a/examples/logs-sqlite3/main.go
+++ b/examples/logs-sqlite3/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"slices"
@@ -11,32 +12,22 @@ import (
 )
 
 func main() {
-	var logLevel sqlslog.Level
-	if slices.Contains(os.Args, "debug") {
-		logLevel = sqlslog.LevelDebug
-	} else if slices.Contains(os.Args, "trace") {
-		logLevel = sqlslog.LevelTrace
-	} else if slices.Contains(os.Args, "verbose") {
-		logLevel = sqlslog.LevelVerbose
-	} else {
-		logLevel = sqlslog.LevelInfo
-	}
-	opts := &slog.HandlerOptions{Level: logLevel}
+	logLevel := sqlslog.ParseLevelWithDefault(os.Args[1], sqlslog.LevelInfo)
 
-	var handler slog.Handler
+	var handlerFunc func(io.Writer, *slog.HandlerOptions) slog.Handler
 	if slices.Contains(os.Args, "json") {
-		handler = sqlslog.NewJSONHandler(os.Stdout, opts)
+		handlerFunc = sqlslog.NewJSONHandler
 	} else {
-		handler = sqlslog.NewTextHandler(os.Stdout, opts)
+		handlerFunc = sqlslog.NewTextHandler
 	}
-	logger := slog.New(handler)
 
 	ctx := context.Background()
 	dsn := "file::memory:?cache=shared"
 
 	// Open a database
-	db, err := sqlslog.Open(ctx, "sqlite3", dsn,
-		sqlslog.Logger(logger),
+	db, logger, err := sqlslog.Open(ctx, "sqlite3", dsn,
+		sqlslog.LogLevel(logLevel),
+		sqlslog.HandlerFunc(handlerFunc),
 		sqlslog.ConnQueryContext(func(o *sqlslog.StepOptions) {
 			o.SetLevel(sqlslog.LevelDebug)
 		}),

--- a/examples/logs-sqlite3/results/debug-log.txt
+++ b/examples/logs-sqlite3/results/debug-log.txt
@@ -1,22 +1,21 @@
-go run . debug text
-time=2025-02-19T07:59:51.443+09:00 level=DEBUG msg=Open driver=sqlite3 dsn="file::memory:?cache=shared"
-time=2025-02-19T07:59:51.444+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=44333
-time=2025-02-19T07:59:51.444+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T07:59:51.444+09:00 level=DEBUG msg=Driver.Open dsn="file::memory:?cache=shared"
-time=2025-02-19T07:59:51.444+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=762708 conn_id=Gvpx9jSceOrGjuoM
-time=2025-02-19T07:59:51.444+09:00 level=INFO msg=Connector.Connect duration=777958
-time=2025-02-19T07:59:51.444+09:00 level=DEBUG msg=Conn.ExecContext conn_id=Gvpx9jSceOrGjuoM query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-19T07:59:51.445+09:00 level=INFO msg=Conn.ExecContext conn_id=Gvpx9jSceOrGjuoM query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=91458
-time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Conn.BeginTx conn_id=Gvpx9jSceOrGjuoM
-time=2025-02-19T07:59:51.445+09:00 level=INFO msg=Conn.BeginTx conn_id=Gvpx9jSceOrGjuoM duration=3875 tx_id=70EIAt3JiGnwEoJH
-time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Conn.ExecContext conn_id=Gvpx9jSceOrGjuoM query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]"
-time=2025-02-19T07:59:51.445+09:00 level=INFO msg=Conn.ExecContext conn_id=Gvpx9jSceOrGjuoM query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=11084
-time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Tx.Commit conn_id=Gvpx9jSceOrGjuoM tx_id=70EIAt3JiGnwEoJH
-time=2025-02-19T07:59:51.445+09:00 level=INFO msg=Tx.Commit conn_id=Gvpx9jSceOrGjuoM tx_id=70EIAt3JiGnwEoJH duration=3958
-time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Conn.QueryContext conn_id=Gvpx9jSceOrGjuoM query="SELECT * FROM test1" args=[] duration=6125
-time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Rows.Next conn_id=Gvpx9jSceOrGjuoM duration=3625 eof=false
-time=2025-02-19T07:59:51.445+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Rows.Next conn_id=Gvpx9jSceOrGjuoM duration=1209 eof=true
-time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Rows.Close conn_id=Gvpx9jSceOrGjuoM duration=625
-time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Conn.Close conn_id=Gvpx9jSceOrGjuoM
-time=2025-02-19T07:59:51.445+09:00 level=INFO msg=Conn.Close conn_id=Gvpx9jSceOrGjuoM duration=14208
+time=2025-02-19T08:24:36.126+09:00 level=DEBUG msg=Open driver=sqlite3 dsn="file::memory:?cache=shared"
+time=2025-02-19T08:24:36.126+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=39584
+time=2025-02-19T08:24:36.126+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:24:36.126+09:00 level=DEBUG msg=Driver.Open dsn="file::memory:?cache=shared"
+time=2025-02-19T08:24:36.127+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=663833 conn_id=v87XIbB1VCtfz8ug
+time=2025-02-19T08:24:36.127+09:00 level=INFO msg=Connector.Connect duration=678334
+time=2025-02-19T08:24:36.127+09:00 level=DEBUG msg=Conn.ExecContext conn_id=v87XIbB1VCtfz8ug query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:24:36.127+09:00 level=INFO msg=Conn.ExecContext conn_id=v87XIbB1VCtfz8ug query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=82166
+time=2025-02-19T08:24:36.127+09:00 level=DEBUG msg=Conn.BeginTx conn_id=v87XIbB1VCtfz8ug
+time=2025-02-19T08:24:36.127+09:00 level=INFO msg=Conn.BeginTx conn_id=v87XIbB1VCtfz8ug duration=3416 tx_id=_VTpZnAgatTSPBfT
+time=2025-02-19T08:24:36.127+09:00 level=DEBUG msg=Conn.ExecContext conn_id=v87XIbB1VCtfz8ug query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]"
+time=2025-02-19T08:24:36.127+09:00 level=INFO msg=Conn.ExecContext conn_id=v87XIbB1VCtfz8ug query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=8750
+time=2025-02-19T08:24:36.127+09:00 level=DEBUG msg=Tx.Commit conn_id=v87XIbB1VCtfz8ug tx_id=_VTpZnAgatTSPBfT
+time=2025-02-19T08:24:36.127+09:00 level=INFO msg=Tx.Commit conn_id=v87XIbB1VCtfz8ug tx_id=_VTpZnAgatTSPBfT duration=3583
+time=2025-02-19T08:24:36.127+09:00 level=DEBUG msg=Conn.QueryContext conn_id=v87XIbB1VCtfz8ug query="SELECT * FROM test1" args=[] duration=5333
+time=2025-02-19T08:24:36.127+09:00 level=DEBUG msg=Rows.Next conn_id=v87XIbB1VCtfz8ug duration=3083 eof=false
+time=2025-02-19T08:24:36.127+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:24:36.127+09:00 level=DEBUG msg=Rows.Next conn_id=v87XIbB1VCtfz8ug duration=1084 eof=true
+time=2025-02-19T08:24:36.127+09:00 level=DEBUG msg=Rows.Close conn_id=v87XIbB1VCtfz8ug duration=667
+time=2025-02-19T08:24:36.127+09:00 level=DEBUG msg=Conn.Close conn_id=v87XIbB1VCtfz8ug
+time=2025-02-19T08:24:36.127+09:00 level=INFO msg=Conn.Close conn_id=v87XIbB1VCtfz8ug duration=13083

--- a/examples/logs-sqlite3/results/debug-log.txt
+++ b/examples/logs-sqlite3/results/debug-log.txt
@@ -1,22 +1,22 @@
 go run . debug text
-time=2025-02-06T22:15:25.947+09:00 level=DEBUG msg=Open driver=sqlite3 dsn="file::memory:?cache=shared"
-time=2025-02-06T22:15:25.947+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=36583
-time=2025-02-06T22:15:25.947+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:25.947+09:00 level=DEBUG msg=Driver.Open dsn="file::memory:?cache=shared"
-time=2025-02-06T22:15:25.948+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=773791 conn_id=2jXuUgvYcVoh31uq
-time=2025-02-06T22:15:25.948+09:00 level=INFO msg=Connector.Connect duration=789334
-time=2025-02-06T22:15:25.948+09:00 level=DEBUG msg=Conn.ExecContext conn_id=2jXuUgvYcVoh31uq query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-06T22:15:25.948+09:00 level=INFO msg=Conn.ExecContext conn_id=2jXuUgvYcVoh31uq query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=102125
-time=2025-02-06T22:15:25.948+09:00 level=DEBUG msg=Conn.BeginTx conn_id=2jXuUgvYcVoh31uq
-time=2025-02-06T22:15:25.948+09:00 level=INFO msg=Conn.BeginTx conn_id=2jXuUgvYcVoh31uq duration=4000 tx_id=cFQIEN4ddGKkcRuR
-time=2025-02-06T22:15:25.948+09:00 level=DEBUG msg=Conn.ExecContext conn_id=2jXuUgvYcVoh31uq query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]"
-time=2025-02-06T22:15:25.948+09:00 level=INFO msg=Conn.ExecContext conn_id=2jXuUgvYcVoh31uq query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=10042
-time=2025-02-06T22:15:25.948+09:00 level=DEBUG msg=Tx.Commit conn_id=2jXuUgvYcVoh31uq tx_id=cFQIEN4ddGKkcRuR
-time=2025-02-06T22:15:25.948+09:00 level=INFO msg=Tx.Commit conn_id=2jXuUgvYcVoh31uq tx_id=cFQIEN4ddGKkcRuR duration=4250
-time=2025-02-06T22:15:25.948+09:00 level=DEBUG msg=Conn.QueryContext conn_id=2jXuUgvYcVoh31uq query="SELECT * FROM test1" args=[] duration=6458
-time=2025-02-06T22:15:25.948+09:00 level=DEBUG msg=Rows.Next conn_id=2jXuUgvYcVoh31uq duration=3792 eof=false
-time=2025-02-06T22:15:25.948+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-06T22:15:25.948+09:00 level=DEBUG msg=Rows.Next conn_id=2jXuUgvYcVoh31uq duration=1375 eof=true
-time=2025-02-06T22:15:25.948+09:00 level=DEBUG msg=Rows.Close conn_id=2jXuUgvYcVoh31uq duration=750
-time=2025-02-06T22:15:25.948+09:00 level=DEBUG msg=Conn.Close conn_id=2jXuUgvYcVoh31uq
-time=2025-02-06T22:15:25.948+09:00 level=INFO msg=Conn.Close conn_id=2jXuUgvYcVoh31uq duration=16167
+time=2025-02-19T07:59:51.443+09:00 level=DEBUG msg=Open driver=sqlite3 dsn="file::memory:?cache=shared"
+time=2025-02-19T07:59:51.444+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=44333
+time=2025-02-19T07:59:51.444+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T07:59:51.444+09:00 level=DEBUG msg=Driver.Open dsn="file::memory:?cache=shared"
+time=2025-02-19T07:59:51.444+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=762708 conn_id=Gvpx9jSceOrGjuoM
+time=2025-02-19T07:59:51.444+09:00 level=INFO msg=Connector.Connect duration=777958
+time=2025-02-19T07:59:51.444+09:00 level=DEBUG msg=Conn.ExecContext conn_id=Gvpx9jSceOrGjuoM query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T07:59:51.445+09:00 level=INFO msg=Conn.ExecContext conn_id=Gvpx9jSceOrGjuoM query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=91458
+time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Conn.BeginTx conn_id=Gvpx9jSceOrGjuoM
+time=2025-02-19T07:59:51.445+09:00 level=INFO msg=Conn.BeginTx conn_id=Gvpx9jSceOrGjuoM duration=3875 tx_id=70EIAt3JiGnwEoJH
+time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Conn.ExecContext conn_id=Gvpx9jSceOrGjuoM query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]"
+time=2025-02-19T07:59:51.445+09:00 level=INFO msg=Conn.ExecContext conn_id=Gvpx9jSceOrGjuoM query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=11084
+time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Tx.Commit conn_id=Gvpx9jSceOrGjuoM tx_id=70EIAt3JiGnwEoJH
+time=2025-02-19T07:59:51.445+09:00 level=INFO msg=Tx.Commit conn_id=Gvpx9jSceOrGjuoM tx_id=70EIAt3JiGnwEoJH duration=3958
+time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Conn.QueryContext conn_id=Gvpx9jSceOrGjuoM query="SELECT * FROM test1" args=[] duration=6125
+time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Rows.Next conn_id=Gvpx9jSceOrGjuoM duration=3625 eof=false
+time=2025-02-19T07:59:51.445+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Rows.Next conn_id=Gvpx9jSceOrGjuoM duration=1209 eof=true
+time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Rows.Close conn_id=Gvpx9jSceOrGjuoM duration=625
+time=2025-02-19T07:59:51.445+09:00 level=DEBUG msg=Conn.Close conn_id=Gvpx9jSceOrGjuoM
+time=2025-02-19T07:59:51.445+09:00 level=INFO msg=Conn.Close conn_id=Gvpx9jSceOrGjuoM duration=14208

--- a/examples/logs-sqlite3/results/info-log.txt
+++ b/examples/logs-sqlite3/results/info-log.txt
@@ -1,10 +1,10 @@
 go run . info text
-time=2025-02-06T22:15:25.607+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=88333
-time=2025-02-06T22:15:25.608+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=1060125 conn_id=gHOOP8unQ5Zxw3rt
-time=2025-02-06T22:15:25.608+09:00 level=INFO msg=Connector.Connect duration=1098875
-time=2025-02-06T22:15:25.609+09:00 level=INFO msg=Conn.ExecContext conn_id=gHOOP8unQ5Zxw3rt query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=162834
-time=2025-02-06T22:15:25.609+09:00 level=INFO msg=Conn.BeginTx conn_id=gHOOP8unQ5Zxw3rt duration=6750 tx_id=5eYoZORzmHSBvG34
-time=2025-02-06T22:15:25.609+09:00 level=INFO msg=Conn.ExecContext conn_id=gHOOP8unQ5Zxw3rt query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=19292
-time=2025-02-06T22:15:25.609+09:00 level=INFO msg=Tx.Commit conn_id=gHOOP8unQ5Zxw3rt tx_id=5eYoZORzmHSBvG34 duration=7167
-time=2025-02-06T22:15:25.609+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-06T22:15:25.609+09:00 level=INFO msg=Conn.Close conn_id=gHOOP8unQ5Zxw3rt duration=26500
+time=2025-02-19T07:59:51.124+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=62917
+time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=616375 conn_id=N0rX3I8QwgShUKGW
+time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Connector.Connect duration=625708
+time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Conn.ExecContext conn_id=N0rX3I8QwgShUKGW query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=75209
+time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Conn.BeginTx conn_id=N0rX3I8QwgShUKGW duration=2959 tx_id=FvZR7PquqD76XE8F
+time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Conn.ExecContext conn_id=N0rX3I8QwgShUKGW query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=7292
+time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Tx.Commit conn_id=N0rX3I8QwgShUKGW tx_id=FvZR7PquqD76XE8F duration=3084
+time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Conn.Close conn_id=N0rX3I8QwgShUKGW duration=11834

--- a/examples/logs-sqlite3/results/info-log.txt
+++ b/examples/logs-sqlite3/results/info-log.txt
@@ -1,10 +1,9 @@
-go run . info text
-time=2025-02-19T07:59:51.124+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=62917
-time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=616375 conn_id=N0rX3I8QwgShUKGW
-time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Connector.Connect duration=625708
-time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Conn.ExecContext conn_id=N0rX3I8QwgShUKGW query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=75209
-time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Conn.BeginTx conn_id=N0rX3I8QwgShUKGW duration=2959 tx_id=FvZR7PquqD76XE8F
-time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Conn.ExecContext conn_id=N0rX3I8QwgShUKGW query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=7292
-time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Tx.Commit conn_id=N0rX3I8QwgShUKGW tx_id=FvZR7PquqD76XE8F duration=3084
-time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-19T07:59:51.125+09:00 level=INFO msg=Conn.Close conn_id=N0rX3I8QwgShUKGW duration=11834
+time=2025-02-19T08:24:35.795+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=83541
+time=2025-02-19T08:24:35.796+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=775542 conn_id=ADzZnA7LF2v5b3mP
+time=2025-02-19T08:24:35.796+09:00 level=INFO msg=Connector.Connect duration=792917
+time=2025-02-19T08:24:35.796+09:00 level=INFO msg=Conn.ExecContext conn_id=ADzZnA7LF2v5b3mP query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=104083
+time=2025-02-19T08:24:35.796+09:00 level=INFO msg=Conn.BeginTx conn_id=ADzZnA7LF2v5b3mP duration=4000 tx_id=vLGluRMv1qL1tBJV
+time=2025-02-19T08:24:35.796+09:00 level=INFO msg=Conn.ExecContext conn_id=ADzZnA7LF2v5b3mP query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=11417
+time=2025-02-19T08:24:35.796+09:00 level=INFO msg=Tx.Commit conn_id=ADzZnA7LF2v5b3mP tx_id=vLGluRMv1qL1tBJV duration=4291
+time=2025-02-19T08:24:35.796+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:24:35.796+09:00 level=INFO msg=Conn.Close conn_id=ADzZnA7LF2v5b3mP duration=16083

--- a/examples/logs-sqlite3/results/trace-log.txt
+++ b/examples/logs-sqlite3/results/trace-log.txt
@@ -1,28 +1,28 @@
 go run . trace text
-time=2025-02-06T22:15:26.265+09:00 level=DEBUG msg=Open driver=sqlite3 dsn="file::memory:?cache=shared"
-time=2025-02-06T22:15:26.265+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=33042
-time=2025-02-06T22:15:26.265+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:26.265+09:00 level=DEBUG msg=Driver.Open dsn="file::memory:?cache=shared"
-time=2025-02-06T22:15:26.266+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=787041 conn_id=fvinsfYRQGceZusQ
-time=2025-02-06T22:15:26.266+09:00 level=INFO msg=Connector.Connect duration=803375
-time=2025-02-06T22:15:26.266+09:00 level=DEBUG msg=Conn.ExecContext conn_id=fvinsfYRQGceZusQ query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-06T22:15:26.266+09:00 level=INFO msg=Conn.ExecContext conn_id=fvinsfYRQGceZusQ query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=103792
-time=2025-02-06T22:15:26.266+09:00 level=TRACE msg=Conn.ResetSession conn_id=fvinsfYRQGceZusQ duration=541
-time=2025-02-06T22:15:26.266+09:00 level=DEBUG msg=Conn.BeginTx conn_id=fvinsfYRQGceZusQ
-time=2025-02-06T22:15:26.266+09:00 level=INFO msg=Conn.BeginTx conn_id=fvinsfYRQGceZusQ duration=4375 tx_id=UxGbwnDCYcZowCj3
-time=2025-02-06T22:15:26.266+09:00 level=DEBUG msg=Conn.ExecContext conn_id=fvinsfYRQGceZusQ query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]"
-time=2025-02-06T22:15:26.266+09:00 level=INFO msg=Conn.ExecContext conn_id=fvinsfYRQGceZusQ query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=11500
-time=2025-02-06T22:15:26.266+09:00 level=DEBUG msg=Tx.Commit conn_id=fvinsfYRQGceZusQ tx_id=UxGbwnDCYcZowCj3
-time=2025-02-06T22:15:26.266+09:00 level=INFO msg=Tx.Commit conn_id=fvinsfYRQGceZusQ tx_id=UxGbwnDCYcZowCj3 duration=5000
-time=2025-02-06T22:15:26.266+09:00 level=TRACE msg=Conn.ResetSession conn_id=fvinsfYRQGceZusQ duration=83
-time=2025-02-06T22:15:26.266+09:00 level=TRACE msg=Conn.QueryContext conn_id=fvinsfYRQGceZusQ query="SELECT * FROM test1" args=[]
-time=2025-02-06T22:15:26.266+09:00 level=DEBUG msg=Conn.QueryContext conn_id=fvinsfYRQGceZusQ query="SELECT * FROM test1" args=[] duration=7667
-time=2025-02-06T22:15:26.266+09:00 level=TRACE msg=Rows.Next conn_id=fvinsfYRQGceZusQ
-time=2025-02-06T22:15:26.266+09:00 level=DEBUG msg=Rows.Next conn_id=fvinsfYRQGceZusQ duration=4000 eof=false
-time=2025-02-06T22:15:26.266+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-06T22:15:26.266+09:00 level=TRACE msg=Rows.Next conn_id=fvinsfYRQGceZusQ
-time=2025-02-06T22:15:26.266+09:00 level=DEBUG msg=Rows.Next conn_id=fvinsfYRQGceZusQ duration=1542 eof=true
-time=2025-02-06T22:15:26.266+09:00 level=TRACE msg=Rows.Close conn_id=fvinsfYRQGceZusQ
-time=2025-02-06T22:15:26.266+09:00 level=DEBUG msg=Rows.Close conn_id=fvinsfYRQGceZusQ duration=833
-time=2025-02-06T22:15:26.266+09:00 level=DEBUG msg=Conn.Close conn_id=fvinsfYRQGceZusQ
-time=2025-02-06T22:15:26.266+09:00 level=INFO msg=Conn.Close conn_id=fvinsfYRQGceZusQ duration=16459
+time=2025-02-19T07:59:51.784+09:00 level=DEBUG msg=Open driver=sqlite3 dsn="file::memory:?cache=shared"
+time=2025-02-19T07:59:51.785+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=37750
+time=2025-02-19T07:59:51.785+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T07:59:51.785+09:00 level=DEBUG msg=Driver.Open dsn="file::memory:?cache=shared"
+time=2025-02-19T07:59:51.785+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=675000 conn_id=flxsbLaKDUKTh_Ba
+time=2025-02-19T07:59:51.785+09:00 level=INFO msg=Connector.Connect duration=687916
+time=2025-02-19T07:59:51.785+09:00 level=DEBUG msg=Conn.ExecContext conn_id=flxsbLaKDUKTh_Ba query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T07:59:51.785+09:00 level=INFO msg=Conn.ExecContext conn_id=flxsbLaKDUKTh_Ba query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=84125
+time=2025-02-19T07:59:51.785+09:00 level=TRACE msg=Conn.ResetSession conn_id=flxsbLaKDUKTh_Ba duration=458
+time=2025-02-19T07:59:51.785+09:00 level=DEBUG msg=Conn.BeginTx conn_id=flxsbLaKDUKTh_Ba
+time=2025-02-19T07:59:51.785+09:00 level=INFO msg=Conn.BeginTx conn_id=flxsbLaKDUKTh_Ba duration=3334 tx_id=tF76WpCwuPKRygLk
+time=2025-02-19T07:59:51.785+09:00 level=DEBUG msg=Conn.ExecContext conn_id=flxsbLaKDUKTh_Ba query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]"
+time=2025-02-19T07:59:51.785+09:00 level=INFO msg=Conn.ExecContext conn_id=flxsbLaKDUKTh_Ba query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=10333
+time=2025-02-19T07:59:51.786+09:00 level=DEBUG msg=Tx.Commit conn_id=flxsbLaKDUKTh_Ba tx_id=tF76WpCwuPKRygLk
+time=2025-02-19T07:59:51.786+09:00 level=INFO msg=Tx.Commit conn_id=flxsbLaKDUKTh_Ba tx_id=tF76WpCwuPKRygLk duration=3667
+time=2025-02-19T07:59:51.786+09:00 level=TRACE msg=Conn.ResetSession conn_id=flxsbLaKDUKTh_Ba duration=42
+time=2025-02-19T07:59:51.786+09:00 level=TRACE msg=Conn.QueryContext conn_id=flxsbLaKDUKTh_Ba query="SELECT * FROM test1" args=[]
+time=2025-02-19T07:59:51.786+09:00 level=DEBUG msg=Conn.QueryContext conn_id=flxsbLaKDUKTh_Ba query="SELECT * FROM test1" args=[] duration=6208
+time=2025-02-19T07:59:51.786+09:00 level=TRACE msg=Rows.Next conn_id=flxsbLaKDUKTh_Ba
+time=2025-02-19T07:59:51.786+09:00 level=DEBUG msg=Rows.Next conn_id=flxsbLaKDUKTh_Ba duration=3167 eof=false
+time=2025-02-19T07:59:51.786+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T07:59:51.786+09:00 level=TRACE msg=Rows.Next conn_id=flxsbLaKDUKTh_Ba
+time=2025-02-19T07:59:51.786+09:00 level=DEBUG msg=Rows.Next conn_id=flxsbLaKDUKTh_Ba duration=1125 eof=true
+time=2025-02-19T07:59:51.786+09:00 level=TRACE msg=Rows.Close conn_id=flxsbLaKDUKTh_Ba
+time=2025-02-19T07:59:51.786+09:00 level=DEBUG msg=Rows.Close conn_id=flxsbLaKDUKTh_Ba duration=583
+time=2025-02-19T07:59:51.786+09:00 level=DEBUG msg=Conn.Close conn_id=flxsbLaKDUKTh_Ba
+time=2025-02-19T07:59:51.786+09:00 level=INFO msg=Conn.Close conn_id=flxsbLaKDUKTh_Ba duration=13500

--- a/examples/logs-sqlite3/results/trace-log.txt
+++ b/examples/logs-sqlite3/results/trace-log.txt
@@ -1,28 +1,27 @@
-go run . trace text
-time=2025-02-19T07:59:51.784+09:00 level=DEBUG msg=Open driver=sqlite3 dsn="file::memory:?cache=shared"
-time=2025-02-19T07:59:51.785+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=37750
-time=2025-02-19T07:59:51.785+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T07:59:51.785+09:00 level=DEBUG msg=Driver.Open dsn="file::memory:?cache=shared"
-time=2025-02-19T07:59:51.785+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=675000 conn_id=flxsbLaKDUKTh_Ba
-time=2025-02-19T07:59:51.785+09:00 level=INFO msg=Connector.Connect duration=687916
-time=2025-02-19T07:59:51.785+09:00 level=DEBUG msg=Conn.ExecContext conn_id=flxsbLaKDUKTh_Ba query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-19T07:59:51.785+09:00 level=INFO msg=Conn.ExecContext conn_id=flxsbLaKDUKTh_Ba query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=84125
-time=2025-02-19T07:59:51.785+09:00 level=TRACE msg=Conn.ResetSession conn_id=flxsbLaKDUKTh_Ba duration=458
-time=2025-02-19T07:59:51.785+09:00 level=DEBUG msg=Conn.BeginTx conn_id=flxsbLaKDUKTh_Ba
-time=2025-02-19T07:59:51.785+09:00 level=INFO msg=Conn.BeginTx conn_id=flxsbLaKDUKTh_Ba duration=3334 tx_id=tF76WpCwuPKRygLk
-time=2025-02-19T07:59:51.785+09:00 level=DEBUG msg=Conn.ExecContext conn_id=flxsbLaKDUKTh_Ba query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]"
-time=2025-02-19T07:59:51.785+09:00 level=INFO msg=Conn.ExecContext conn_id=flxsbLaKDUKTh_Ba query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=10333
-time=2025-02-19T07:59:51.786+09:00 level=DEBUG msg=Tx.Commit conn_id=flxsbLaKDUKTh_Ba tx_id=tF76WpCwuPKRygLk
-time=2025-02-19T07:59:51.786+09:00 level=INFO msg=Tx.Commit conn_id=flxsbLaKDUKTh_Ba tx_id=tF76WpCwuPKRygLk duration=3667
-time=2025-02-19T07:59:51.786+09:00 level=TRACE msg=Conn.ResetSession conn_id=flxsbLaKDUKTh_Ba duration=42
-time=2025-02-19T07:59:51.786+09:00 level=TRACE msg=Conn.QueryContext conn_id=flxsbLaKDUKTh_Ba query="SELECT * FROM test1" args=[]
-time=2025-02-19T07:59:51.786+09:00 level=DEBUG msg=Conn.QueryContext conn_id=flxsbLaKDUKTh_Ba query="SELECT * FROM test1" args=[] duration=6208
-time=2025-02-19T07:59:51.786+09:00 level=TRACE msg=Rows.Next conn_id=flxsbLaKDUKTh_Ba
-time=2025-02-19T07:59:51.786+09:00 level=DEBUG msg=Rows.Next conn_id=flxsbLaKDUKTh_Ba duration=3167 eof=false
-time=2025-02-19T07:59:51.786+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-19T07:59:51.786+09:00 level=TRACE msg=Rows.Next conn_id=flxsbLaKDUKTh_Ba
-time=2025-02-19T07:59:51.786+09:00 level=DEBUG msg=Rows.Next conn_id=flxsbLaKDUKTh_Ba duration=1125 eof=true
-time=2025-02-19T07:59:51.786+09:00 level=TRACE msg=Rows.Close conn_id=flxsbLaKDUKTh_Ba
-time=2025-02-19T07:59:51.786+09:00 level=DEBUG msg=Rows.Close conn_id=flxsbLaKDUKTh_Ba duration=583
-time=2025-02-19T07:59:51.786+09:00 level=DEBUG msg=Conn.Close conn_id=flxsbLaKDUKTh_Ba
-time=2025-02-19T07:59:51.786+09:00 level=INFO msg=Conn.Close conn_id=flxsbLaKDUKTh_Ba duration=13500
+time=2025-02-19T08:24:36.449+09:00 level=DEBUG msg=Open driver=sqlite3 dsn="file::memory:?cache=shared"
+time=2025-02-19T08:24:36.449+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=44000
+time=2025-02-19T08:24:36.449+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:24:36.449+09:00 level=DEBUG msg=Driver.Open dsn="file::memory:?cache=shared"
+time=2025-02-19T08:24:36.450+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=824000 conn_id=Z2Xdab0y_7Oxsh_6
+time=2025-02-19T08:24:36.450+09:00 level=INFO msg=Connector.Connect duration=842500
+time=2025-02-19T08:24:36.450+09:00 level=DEBUG msg=Conn.ExecContext conn_id=Z2Xdab0y_7Oxsh_6 query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:24:36.450+09:00 level=INFO msg=Conn.ExecContext conn_id=Z2Xdab0y_7Oxsh_6 query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=100959
+time=2025-02-19T08:24:36.450+09:00 level=TRACE msg=Conn.ResetSession conn_id=Z2Xdab0y_7Oxsh_6 duration=625
+time=2025-02-19T08:24:36.450+09:00 level=DEBUG msg=Conn.BeginTx conn_id=Z2Xdab0y_7Oxsh_6
+time=2025-02-19T08:24:36.450+09:00 level=INFO msg=Conn.BeginTx conn_id=Z2Xdab0y_7Oxsh_6 duration=4250 tx_id=6nxdO4jBuf6O_pPX
+time=2025-02-19T08:24:36.450+09:00 level=DEBUG msg=Conn.ExecContext conn_id=Z2Xdab0y_7Oxsh_6 query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]"
+time=2025-02-19T08:24:36.450+09:00 level=INFO msg=Conn.ExecContext conn_id=Z2Xdab0y_7Oxsh_6 query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=11959
+time=2025-02-19T08:24:36.450+09:00 level=DEBUG msg=Tx.Commit conn_id=Z2Xdab0y_7Oxsh_6 tx_id=6nxdO4jBuf6O_pPX
+time=2025-02-19T08:24:36.450+09:00 level=INFO msg=Tx.Commit conn_id=Z2Xdab0y_7Oxsh_6 tx_id=6nxdO4jBuf6O_pPX duration=4416
+time=2025-02-19T08:24:36.450+09:00 level=TRACE msg=Conn.ResetSession conn_id=Z2Xdab0y_7Oxsh_6 duration=41
+time=2025-02-19T08:24:36.450+09:00 level=TRACE msg=Conn.QueryContext conn_id=Z2Xdab0y_7Oxsh_6 query="SELECT * FROM test1" args=[]
+time=2025-02-19T08:24:36.450+09:00 level=DEBUG msg=Conn.QueryContext conn_id=Z2Xdab0y_7Oxsh_6 query="SELECT * FROM test1" args=[] duration=6833
+time=2025-02-19T08:24:36.450+09:00 level=TRACE msg=Rows.Next conn_id=Z2Xdab0y_7Oxsh_6
+time=2025-02-19T08:24:36.450+09:00 level=DEBUG msg=Rows.Next conn_id=Z2Xdab0y_7Oxsh_6 duration=3625 eof=false
+time=2025-02-19T08:24:36.450+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:24:36.450+09:00 level=TRACE msg=Rows.Next conn_id=Z2Xdab0y_7Oxsh_6
+time=2025-02-19T08:24:36.450+09:00 level=DEBUG msg=Rows.Next conn_id=Z2Xdab0y_7Oxsh_6 duration=1333 eof=true
+time=2025-02-19T08:24:36.450+09:00 level=TRACE msg=Rows.Close conn_id=Z2Xdab0y_7Oxsh_6
+time=2025-02-19T08:24:36.450+09:00 level=DEBUG msg=Rows.Close conn_id=Z2Xdab0y_7Oxsh_6 duration=709
+time=2025-02-19T08:24:36.450+09:00 level=DEBUG msg=Conn.Close conn_id=Z2Xdab0y_7Oxsh_6
+time=2025-02-19T08:24:36.450+09:00 level=INFO msg=Conn.Close conn_id=Z2Xdab0y_7Oxsh_6 duration=16458

--- a/examples/logs-sqlite3/results/verbose-log.json
+++ b/examples/logs-sqlite3/results/verbose-log.json
@@ -1,0 +1,29 @@
+{"time":"2025-02-19T08:24:37.096351+09:00","level":"DEBUG","msg":"Open","driver":"sqlite3","dsn":"file::memory:?cache=shared"}
+{"time":"2025-02-19T08:24:37.096656+09:00","level":"INFO","msg":"Open","driver":"sqlite3","dsn":"file::memory:?cache=shared","duration":47833}
+{"time":"2025-02-19T08:24:37.096698+09:00","level":"DEBUG","msg":"Connector.Connect"}
+{"time":"2025-02-19T08:24:37.096706+09:00","level":"DEBUG","msg":"Driver.Open","dsn":"file::memory:?cache=shared"}
+{"time":"2025-02-19T08:24:37.097456+09:00","level":"INFO","msg":"Driver.Open","dsn":"file::memory:?cache=shared","duration":740708,"conn_id":"Nx415q3F0RGRnLis"}
+{"time":"2025-02-19T08:24:37.097465+09:00","level":"INFO","msg":"Connector.Connect","duration":760959}
+{"time":"2025-02-19T08:24:37.097474+09:00","level":"DEBUG","msg":"Conn.ExecContext","conn_id":"Nx415q3F0RGRnLis","query":"CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))","args":"[]"}
+{"time":"2025-02-19T08:24:37.097572+09:00","level":"INFO","msg":"Conn.ExecContext","conn_id":"Nx415q3F0RGRnLis","query":"CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))","args":"[]","duration":91667}
+{"time":"2025-02-19T08:24:37.09758+09:00","level":"VERBOSE","msg":"Conn.ResetSession","conn_id":"Nx415q3F0RGRnLis"}
+{"time":"2025-02-19T08:24:37.097586+09:00","level":"TRACE","msg":"Conn.ResetSession","conn_id":"Nx415q3F0RGRnLis","duration":541}
+{"time":"2025-02-19T08:24:37.097591+09:00","level":"DEBUG","msg":"Conn.BeginTx","conn_id":"Nx415q3F0RGRnLis"}
+{"time":"2025-02-19T08:24:37.097599+09:00","level":"INFO","msg":"Conn.BeginTx","conn_id":"Nx415q3F0RGRnLis","duration":3541,"tx_id":"3ri_Ws3oiqkQuC81"}
+{"time":"2025-02-19T08:24:37.097635+09:00","level":"DEBUG","msg":"Conn.ExecContext","conn_id":"Nx415q3F0RGRnLis","query":"INSERT INTO test1 (name) VALUES (?)","args":"[{Name: Ordinal:1 Value:Alice}]"}
+{"time":"2025-02-19T08:24:37.097652+09:00","level":"INFO","msg":"Conn.ExecContext","conn_id":"Nx415q3F0RGRnLis","query":"INSERT INTO test1 (name) VALUES (?)","args":"[{Name: Ordinal:1 Value:Alice}]","duration":8916}
+{"time":"2025-02-19T08:24:37.097671+09:00","level":"DEBUG","msg":"Tx.Commit","conn_id":"Nx415q3F0RGRnLis","tx_id":"3ri_Ws3oiqkQuC81"}
+{"time":"2025-02-19T08:24:37.09768+09:00","level":"INFO","msg":"Tx.Commit","conn_id":"Nx415q3F0RGRnLis","tx_id":"3ri_Ws3oiqkQuC81","duration":3834}
+{"time":"2025-02-19T08:24:37.097685+09:00","level":"VERBOSE","msg":"Conn.ResetSession","conn_id":"Nx415q3F0RGRnLis"}
+{"time":"2025-02-19T08:24:37.09769+09:00","level":"TRACE","msg":"Conn.ResetSession","conn_id":"Nx415q3F0RGRnLis","duration":83}
+{"time":"2025-02-19T08:24:37.097696+09:00","level":"TRACE","msg":"Conn.QueryContext","conn_id":"Nx415q3F0RGRnLis","query":"SELECT * FROM test1","args":"[]"}
+{"time":"2025-02-19T08:24:37.097706+09:00","level":"DEBUG","msg":"Conn.QueryContext","conn_id":"Nx415q3F0RGRnLis","query":"SELECT * FROM test1","args":"[]","duration":5708}
+{"time":"2025-02-19T08:24:37.097713+09:00","level":"TRACE","msg":"Rows.Next","conn_id":"Nx415q3F0RGRnLis"}
+{"time":"2025-02-19T08:24:37.097722+09:00","level":"DEBUG","msg":"Rows.Next","conn_id":"Nx415q3F0RGRnLis","duration":3375,"eof":false}
+{"time":"2025-02-19T08:24:37.09774+09:00","level":"INFO","msg":"Record","id":1,"name":"Alice"}
+{"time":"2025-02-19T08:24:37.097745+09:00","level":"TRACE","msg":"Rows.Next","conn_id":"Nx415q3F0RGRnLis"}
+{"time":"2025-02-19T08:24:37.097752+09:00","level":"DEBUG","msg":"Rows.Next","conn_id":"Nx415q3F0RGRnLis","duration":1167,"eof":true}
+{"time":"2025-02-19T08:24:37.097757+09:00","level":"TRACE","msg":"Rows.Close","conn_id":"Nx415q3F0RGRnLis"}
+{"time":"2025-02-19T08:24:37.097762+09:00","level":"DEBUG","msg":"Rows.Close","conn_id":"Nx415q3F0RGRnLis","duration":708}
+{"time":"2025-02-19T08:24:37.097768+09:00","level":"DEBUG","msg":"Conn.Close","conn_id":"Nx415q3F0RGRnLis"}
+{"time":"2025-02-19T08:24:37.097787+09:00","level":"INFO","msg":"Conn.Close","conn_id":"Nx415q3F0RGRnLis","duration":14250}

--- a/examples/logs-sqlite3/results/verbose-log.txt
+++ b/examples/logs-sqlite3/results/verbose-log.txt
@@ -1,30 +1,30 @@
 go run . verbose text
-time=2025-02-06T22:15:26.586+09:00 level=DEBUG msg=Open driver=sqlite3 dsn="file::memory:?cache=shared"
-time=2025-02-06T22:15:26.586+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=27416
-time=2025-02-06T22:15:26.586+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-06T22:15:26.586+09:00 level=DEBUG msg=Driver.Open dsn="file::memory:?cache=shared"
-time=2025-02-06T22:15:26.587+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=615125 conn_id=Sid0qDG9HGKGad8N
-time=2025-02-06T22:15:26.587+09:00 level=INFO msg=Connector.Connect duration=627041
-time=2025-02-06T22:15:26.587+09:00 level=DEBUG msg=Conn.ExecContext conn_id=Sid0qDG9HGKGad8N query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-06T22:15:26.587+09:00 level=INFO msg=Conn.ExecContext conn_id=Sid0qDG9HGKGad8N query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=80500
-time=2025-02-06T22:15:26.587+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=Sid0qDG9HGKGad8N
-time=2025-02-06T22:15:26.587+09:00 level=TRACE msg=Conn.ResetSession conn_id=Sid0qDG9HGKGad8N duration=500
-time=2025-02-06T22:15:26.587+09:00 level=DEBUG msg=Conn.BeginTx conn_id=Sid0qDG9HGKGad8N
-time=2025-02-06T22:15:26.587+09:00 level=INFO msg=Conn.BeginTx conn_id=Sid0qDG9HGKGad8N duration=3208 tx_id=gjw5TYfBOoWLyGN0
-time=2025-02-06T22:15:26.587+09:00 level=DEBUG msg=Conn.ExecContext conn_id=Sid0qDG9HGKGad8N query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]"
-time=2025-02-06T22:15:26.587+09:00 level=INFO msg=Conn.ExecContext conn_id=Sid0qDG9HGKGad8N query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=7916
-time=2025-02-06T22:15:26.587+09:00 level=DEBUG msg=Tx.Commit conn_id=Sid0qDG9HGKGad8N tx_id=gjw5TYfBOoWLyGN0
-time=2025-02-06T22:15:26.587+09:00 level=INFO msg=Tx.Commit conn_id=Sid0qDG9HGKGad8N tx_id=gjw5TYfBOoWLyGN0 duration=3375
-time=2025-02-06T22:15:26.587+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=Sid0qDG9HGKGad8N
-time=2025-02-06T22:15:26.587+09:00 level=TRACE msg=Conn.ResetSession conn_id=Sid0qDG9HGKGad8N duration=83
-time=2025-02-06T22:15:26.587+09:00 level=TRACE msg=Conn.QueryContext conn_id=Sid0qDG9HGKGad8N query="SELECT * FROM test1" args=[]
-time=2025-02-06T22:15:26.587+09:00 level=DEBUG msg=Conn.QueryContext conn_id=Sid0qDG9HGKGad8N query="SELECT * FROM test1" args=[] duration=5000
-time=2025-02-06T22:15:26.587+09:00 level=TRACE msg=Rows.Next conn_id=Sid0qDG9HGKGad8N
-time=2025-02-06T22:15:26.587+09:00 level=DEBUG msg=Rows.Next conn_id=Sid0qDG9HGKGad8N duration=3167 eof=false
-time=2025-02-06T22:15:26.587+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-06T22:15:26.587+09:00 level=TRACE msg=Rows.Next conn_id=Sid0qDG9HGKGad8N
-time=2025-02-06T22:15:26.587+09:00 level=DEBUG msg=Rows.Next conn_id=Sid0qDG9HGKGad8N duration=1083 eof=true
-time=2025-02-06T22:15:26.587+09:00 level=TRACE msg=Rows.Close conn_id=Sid0qDG9HGKGad8N
-time=2025-02-06T22:15:26.587+09:00 level=DEBUG msg=Rows.Close conn_id=Sid0qDG9HGKGad8N duration=583
-time=2025-02-06T22:15:26.587+09:00 level=DEBUG msg=Conn.Close conn_id=Sid0qDG9HGKGad8N
-time=2025-02-06T22:15:26.587+09:00 level=INFO msg=Conn.Close conn_id=Sid0qDG9HGKGad8N duration=12416
+time=2025-02-19T07:59:52.119+09:00 level=DEBUG msg=Open driver=sqlite3 dsn="file::memory:?cache=shared"
+time=2025-02-19T07:59:52.119+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=44625
+time=2025-02-19T07:59:52.120+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T07:59:52.120+09:00 level=DEBUG msg=Driver.Open dsn="file::memory:?cache=shared"
+time=2025-02-19T07:59:52.120+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=794792 conn_id=DP5djqmBVDTFYMh0
+time=2025-02-19T07:59:52.120+09:00 level=INFO msg=Connector.Connect duration=809042
+time=2025-02-19T07:59:52.120+09:00 level=DEBUG msg=Conn.ExecContext conn_id=DP5djqmBVDTFYMh0 query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T07:59:52.120+09:00 level=INFO msg=Conn.ExecContext conn_id=DP5djqmBVDTFYMh0 query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=93125
+time=2025-02-19T07:59:52.120+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=DP5djqmBVDTFYMh0
+time=2025-02-19T07:59:52.120+09:00 level=TRACE msg=Conn.ResetSession conn_id=DP5djqmBVDTFYMh0 duration=584
+time=2025-02-19T07:59:52.120+09:00 level=DEBUG msg=Conn.BeginTx conn_id=DP5djqmBVDTFYMh0
+time=2025-02-19T07:59:52.120+09:00 level=INFO msg=Conn.BeginTx conn_id=DP5djqmBVDTFYMh0 duration=3708 tx_id=NLsrIB4XkEah45lk
+time=2025-02-19T07:59:52.120+09:00 level=DEBUG msg=Conn.ExecContext conn_id=DP5djqmBVDTFYMh0 query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]"
+time=2025-02-19T07:59:52.121+09:00 level=INFO msg=Conn.ExecContext conn_id=DP5djqmBVDTFYMh0 query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=9250
+time=2025-02-19T07:59:52.121+09:00 level=DEBUG msg=Tx.Commit conn_id=DP5djqmBVDTFYMh0 tx_id=NLsrIB4XkEah45lk
+time=2025-02-19T07:59:52.121+09:00 level=INFO msg=Tx.Commit conn_id=DP5djqmBVDTFYMh0 tx_id=NLsrIB4XkEah45lk duration=4000
+time=2025-02-19T07:59:52.121+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=DP5djqmBVDTFYMh0
+time=2025-02-19T07:59:52.121+09:00 level=TRACE msg=Conn.ResetSession conn_id=DP5djqmBVDTFYMh0 duration=83
+time=2025-02-19T07:59:52.121+09:00 level=TRACE msg=Conn.QueryContext conn_id=DP5djqmBVDTFYMh0 query="SELECT * FROM test1" args=[]
+time=2025-02-19T07:59:52.121+09:00 level=DEBUG msg=Conn.QueryContext conn_id=DP5djqmBVDTFYMh0 query="SELECT * FROM test1" args=[] duration=5916
+time=2025-02-19T07:59:52.121+09:00 level=TRACE msg=Rows.Next conn_id=DP5djqmBVDTFYMh0
+time=2025-02-19T07:59:52.121+09:00 level=DEBUG msg=Rows.Next conn_id=DP5djqmBVDTFYMh0 duration=3458 eof=false
+time=2025-02-19T07:59:52.121+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T07:59:52.121+09:00 level=TRACE msg=Rows.Next conn_id=DP5djqmBVDTFYMh0
+time=2025-02-19T07:59:52.121+09:00 level=DEBUG msg=Rows.Next conn_id=DP5djqmBVDTFYMh0 duration=1167 eof=true
+time=2025-02-19T07:59:52.121+09:00 level=TRACE msg=Rows.Close conn_id=DP5djqmBVDTFYMh0
+time=2025-02-19T07:59:52.121+09:00 level=DEBUG msg=Rows.Close conn_id=DP5djqmBVDTFYMh0 duration=625
+time=2025-02-19T07:59:52.121+09:00 level=DEBUG msg=Conn.Close conn_id=DP5djqmBVDTFYMh0
+time=2025-02-19T07:59:52.121+09:00 level=INFO msg=Conn.Close conn_id=DP5djqmBVDTFYMh0 duration=14375

--- a/examples/logs-sqlite3/results/verbose-log.txt
+++ b/examples/logs-sqlite3/results/verbose-log.txt
@@ -1,30 +1,29 @@
-go run . verbose text
-time=2025-02-19T07:59:52.119+09:00 level=DEBUG msg=Open driver=sqlite3 dsn="file::memory:?cache=shared"
-time=2025-02-19T07:59:52.119+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=44625
-time=2025-02-19T07:59:52.120+09:00 level=DEBUG msg=Connector.Connect
-time=2025-02-19T07:59:52.120+09:00 level=DEBUG msg=Driver.Open dsn="file::memory:?cache=shared"
-time=2025-02-19T07:59:52.120+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=794792 conn_id=DP5djqmBVDTFYMh0
-time=2025-02-19T07:59:52.120+09:00 level=INFO msg=Connector.Connect duration=809042
-time=2025-02-19T07:59:52.120+09:00 level=DEBUG msg=Conn.ExecContext conn_id=DP5djqmBVDTFYMh0 query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
-time=2025-02-19T07:59:52.120+09:00 level=INFO msg=Conn.ExecContext conn_id=DP5djqmBVDTFYMh0 query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=93125
-time=2025-02-19T07:59:52.120+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=DP5djqmBVDTFYMh0
-time=2025-02-19T07:59:52.120+09:00 level=TRACE msg=Conn.ResetSession conn_id=DP5djqmBVDTFYMh0 duration=584
-time=2025-02-19T07:59:52.120+09:00 level=DEBUG msg=Conn.BeginTx conn_id=DP5djqmBVDTFYMh0
-time=2025-02-19T07:59:52.120+09:00 level=INFO msg=Conn.BeginTx conn_id=DP5djqmBVDTFYMh0 duration=3708 tx_id=NLsrIB4XkEah45lk
-time=2025-02-19T07:59:52.120+09:00 level=DEBUG msg=Conn.ExecContext conn_id=DP5djqmBVDTFYMh0 query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]"
-time=2025-02-19T07:59:52.121+09:00 level=INFO msg=Conn.ExecContext conn_id=DP5djqmBVDTFYMh0 query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=9250
-time=2025-02-19T07:59:52.121+09:00 level=DEBUG msg=Tx.Commit conn_id=DP5djqmBVDTFYMh0 tx_id=NLsrIB4XkEah45lk
-time=2025-02-19T07:59:52.121+09:00 level=INFO msg=Tx.Commit conn_id=DP5djqmBVDTFYMh0 tx_id=NLsrIB4XkEah45lk duration=4000
-time=2025-02-19T07:59:52.121+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=DP5djqmBVDTFYMh0
-time=2025-02-19T07:59:52.121+09:00 level=TRACE msg=Conn.ResetSession conn_id=DP5djqmBVDTFYMh0 duration=83
-time=2025-02-19T07:59:52.121+09:00 level=TRACE msg=Conn.QueryContext conn_id=DP5djqmBVDTFYMh0 query="SELECT * FROM test1" args=[]
-time=2025-02-19T07:59:52.121+09:00 level=DEBUG msg=Conn.QueryContext conn_id=DP5djqmBVDTFYMh0 query="SELECT * FROM test1" args=[] duration=5916
-time=2025-02-19T07:59:52.121+09:00 level=TRACE msg=Rows.Next conn_id=DP5djqmBVDTFYMh0
-time=2025-02-19T07:59:52.121+09:00 level=DEBUG msg=Rows.Next conn_id=DP5djqmBVDTFYMh0 duration=3458 eof=false
-time=2025-02-19T07:59:52.121+09:00 level=INFO msg=Record id=1 name=Alice
-time=2025-02-19T07:59:52.121+09:00 level=TRACE msg=Rows.Next conn_id=DP5djqmBVDTFYMh0
-time=2025-02-19T07:59:52.121+09:00 level=DEBUG msg=Rows.Next conn_id=DP5djqmBVDTFYMh0 duration=1167 eof=true
-time=2025-02-19T07:59:52.121+09:00 level=TRACE msg=Rows.Close conn_id=DP5djqmBVDTFYMh0
-time=2025-02-19T07:59:52.121+09:00 level=DEBUG msg=Rows.Close conn_id=DP5djqmBVDTFYMh0 duration=625
-time=2025-02-19T07:59:52.121+09:00 level=DEBUG msg=Conn.Close conn_id=DP5djqmBVDTFYMh0
-time=2025-02-19T07:59:52.121+09:00 level=INFO msg=Conn.Close conn_id=DP5djqmBVDTFYMh0 duration=14375
+time=2025-02-19T08:24:36.778+09:00 level=DEBUG msg=Open driver=sqlite3 dsn="file::memory:?cache=shared"
+time=2025-02-19T08:24:36.778+09:00 level=INFO msg=Open driver=sqlite3 dsn="file::memory:?cache=shared" duration=48834
+time=2025-02-19T08:24:36.778+09:00 level=DEBUG msg=Connector.Connect
+time=2025-02-19T08:24:36.778+09:00 level=DEBUG msg=Driver.Open dsn="file::memory:?cache=shared"
+time=2025-02-19T08:24:36.779+09:00 level=INFO msg=Driver.Open dsn="file::memory:?cache=shared" duration=812541 conn_id=DHIaKg4dGsNaJKno
+time=2025-02-19T08:24:36.779+09:00 level=INFO msg=Connector.Connect duration=830875
+time=2025-02-19T08:24:36.779+09:00 level=DEBUG msg=Conn.ExecContext conn_id=DHIaKg4dGsNaJKno query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[]
+time=2025-02-19T08:24:36.779+09:00 level=INFO msg=Conn.ExecContext conn_id=DHIaKg4dGsNaJKno query="CREATE TABLE IF NOT EXISTS test1 (id INTEGER PRIMARY KEY, name VARCHAR(255))" args=[] duration=103542
+time=2025-02-19T08:24:36.779+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=DHIaKg4dGsNaJKno
+time=2025-02-19T08:24:36.779+09:00 level=TRACE msg=Conn.ResetSession conn_id=DHIaKg4dGsNaJKno duration=708
+time=2025-02-19T08:24:36.779+09:00 level=DEBUG msg=Conn.BeginTx conn_id=DHIaKg4dGsNaJKno
+time=2025-02-19T08:24:36.779+09:00 level=INFO msg=Conn.BeginTx conn_id=DHIaKg4dGsNaJKno duration=4166 tx_id=p3TnEFe42_hv1aFr
+time=2025-02-19T08:24:36.779+09:00 level=DEBUG msg=Conn.ExecContext conn_id=DHIaKg4dGsNaJKno query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]"
+time=2025-02-19T08:24:36.779+09:00 level=INFO msg=Conn.ExecContext conn_id=DHIaKg4dGsNaJKno query="INSERT INTO test1 (name) VALUES (?)" args="[{Name: Ordinal:1 Value:Alice}]" duration=9750
+time=2025-02-19T08:24:36.779+09:00 level=DEBUG msg=Tx.Commit conn_id=DHIaKg4dGsNaJKno tx_id=p3TnEFe42_hv1aFr
+time=2025-02-19T08:24:36.779+09:00 level=INFO msg=Tx.Commit conn_id=DHIaKg4dGsNaJKno tx_id=p3TnEFe42_hv1aFr duration=4375
+time=2025-02-19T08:24:36.779+09:00 level=VERBOSE msg=Conn.ResetSession conn_id=DHIaKg4dGsNaJKno
+time=2025-02-19T08:24:36.779+09:00 level=TRACE msg=Conn.ResetSession conn_id=DHIaKg4dGsNaJKno duration=125
+time=2025-02-19T08:24:36.779+09:00 level=TRACE msg=Conn.QueryContext conn_id=DHIaKg4dGsNaJKno query="SELECT * FROM test1" args=[]
+time=2025-02-19T08:24:36.779+09:00 level=DEBUG msg=Conn.QueryContext conn_id=DHIaKg4dGsNaJKno query="SELECT * FROM test1" args=[] duration=6583
+time=2025-02-19T08:24:36.779+09:00 level=TRACE msg=Rows.Next conn_id=DHIaKg4dGsNaJKno
+time=2025-02-19T08:24:36.779+09:00 level=DEBUG msg=Rows.Next conn_id=DHIaKg4dGsNaJKno duration=3667 eof=false
+time=2025-02-19T08:24:36.779+09:00 level=INFO msg=Record id=1 name=Alice
+time=2025-02-19T08:24:36.779+09:00 level=TRACE msg=Rows.Next conn_id=DHIaKg4dGsNaJKno
+time=2025-02-19T08:24:36.779+09:00 level=DEBUG msg=Rows.Next conn_id=DHIaKg4dGsNaJKno duration=1375 eof=true
+time=2025-02-19T08:24:36.779+09:00 level=TRACE msg=Rows.Close conn_id=DHIaKg4dGsNaJKno
+time=2025-02-19T08:24:36.779+09:00 level=DEBUG msg=Rows.Close conn_id=DHIaKg4dGsNaJKno duration=833
+time=2025-02-19T08:24:36.779+09:00 level=DEBUG msg=Conn.Close conn_id=DHIaKg4dGsNaJKno
+time=2025-02-19T08:24:36.779+09:00 level=INFO msg=Conn.Close conn_id=DHIaKg4dGsNaJKno duration=15958

--- a/examples/logs.mk
+++ b/examples/logs.mk
@@ -1,6 +1,6 @@
 .PHONY: run
 run:
-	go run . ${LOG_LEVEL} ${LOG_FORMAT}
+	@go run . ${LOG_LEVEL} ${LOG_FORMAT}
 
 RESULTS_DIR=results
 $(RESULTS_DIR):

--- a/examples/logs.mk
+++ b/examples/logs.mk
@@ -16,7 +16,7 @@ gen-text-logs: gen-text-logs-info gen-text-logs-debug gen-text-logs-trace gen-te
 gen-json-logs: gen-json-logs-info gen-json-logs-debug gen-json-logs-trace gen-json-logs-verbose
 
 .PHONY: gen
-gen: gen-text-logs gen-json-logs
+gen: gen-text-logs gen-json-logs-verbose
 
 .PHONY: clean
 clean:

--- a/examples/logs.mk
+++ b/examples/logs.mk
@@ -9,8 +9,14 @@ $(RESULTS_DIR):
 gen-text-logs-%: $(RESULTS_DIR)
 	LOG_LEVEL=$* LOG_FORMAT=text $(MAKE) run > $(RESULTS_DIR)/$*-log.txt
 
+gen-json-logs-%: $(RESULTS_DIR)
+	LOG_LEVEL=$* LOG_FORMAT=json $(MAKE) run > $(RESULTS_DIR)/$*-log.json
+
+gen-text-logs: gen-text-logs-info gen-text-logs-debug gen-text-logs-trace gen-text-logs-verbose
+gen-json-logs: gen-json-logs-info gen-json-logs-debug gen-json-logs-trace gen-json-logs-verbose
+
 .PHONY: gen
-gen: gen-text-logs-info gen-text-logs-debug gen-text-logs-trace gen-text-logs-verbose
+gen: gen-text-logs gen-json-logs
 
 .PHONY: clean
 clean:

--- a/factory.go
+++ b/factory.go
@@ -7,21 +7,6 @@ import (
 	"log/slog"
 )
 
-type factoryOptions struct {
-	Open          StepOptions
-	DriverOptions *driverOptions
-	SlogOptions   *slogOptions
-}
-
-func defaultFactoryOptions(driverName string, msgb StepEventMsgBuilder) *factoryOptions {
-	driverOptions := defaultDriverOptions(driverName, msgb)
-	return &factoryOptions{
-		Open:          *defaultStepOptions(msgb, StepSqlslogOpen, LevelInfo),
-		DriverOptions: driverOptions,
-		SlogOptions:   defaultSlogOptions(),
-	}
-}
-
 type Factory struct {
 	options    *options
 	driverName string
@@ -38,7 +23,7 @@ func New(driverName, dsn string, opts ...Option) *Factory {
 
 func (f *Factory) Handler() slog.Handler {
 	if f.handler == nil {
-		f.handler = f.options.factoryOptions.SlogOptions.newHandler()
+		f.handler = f.options.SlogOptions.newHandler()
 	}
 	return f.handler
 }
@@ -56,10 +41,10 @@ func (f *Factory) Open(ctx context.Context) (*sql.DB, error) {
 		durationKey:  f.options.durationKey,
 		durationType: f.options.durationType,
 	})
-	return open(ctx, f.driverName, f.dsn, logger, &f.options.factoryOptions)
+	return open(ctx, f.driverName, f.dsn, logger, f.options)
 }
 
-func open(ctx context.Context, driverName, dsn string, logger *stepLogger, options *factoryOptions) (*sql.DB, error) {
+func open(ctx context.Context, driverName, dsn string, logger *stepLogger, options *options) (*sql.DB, error) {
 	lg := logger.With(
 		slog.String("driver", driverName),
 		slog.String("dsn", dsn),

--- a/factory.go
+++ b/factory.go
@@ -3,6 +3,7 @@ package sqlslog
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"log/slog"
 )
 
@@ -28,4 +29,50 @@ func (f *Factory) Open(ctx context.Context) (*sql.DB, error) {
 		durationType: f.options.durationType,
 	})
 	return open(ctx, f.driverName, f.dsn, logger, &f.options.sqlslogOptions)
+}
+
+func open(ctx context.Context, driverName, dsn string, logger *stepLogger, options *sqlslogOptions) (*sql.DB, error) {
+	lg := logger.With(
+		slog.String("driver", driverName),
+		slog.String("dsn", dsn),
+	)
+
+	var db *sql.DB
+	err := ignoreAttr(lg.Step(ctx, &options.Open, func() (*slog.Attr, error) {
+		var err error
+		db, err = openWithDriver(driverName, dsn, logger, options.DriverOptions)
+		return nil, err
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+func openWithDriver(driverName, dsn string, logger *stepLogger, driverOptions *driverOptions) (*sql.DB, error) {
+	db, err := sql.Open(driverName, dsn)
+	if err != nil {
+		return nil, err
+	}
+	// This db is not used directly, but it is used to get the driver.
+
+	drv := wrapDriver(db.Driver(), logger, driverOptions)
+
+	return openWithWrappedDriver(drv, dsn, logger, driverOptions)
+}
+
+func openWithWrappedDriver(drv driver.Driver, dsn string, logger *stepLogger, driverOptions *driverOptions) (*sql.DB, error) {
+	var origConnector driver.Connector
+
+	if dc, ok := drv.(driver.DriverContext); ok {
+		connector, err := dc.OpenConnector(dsn)
+		if err != nil {
+			return nil, err
+		}
+		origConnector = connector
+	} else {
+		origConnector = &dsnConnector{dsn: dsn, driver: drv}
+	}
+
+	return sql.OpenDB(wrapConnector(origConnector, logger, driverOptions.ConnectorOptions)), nil
 }

--- a/factory.go
+++ b/factory.go
@@ -7,6 +7,19 @@ import (
 	"log/slog"
 )
 
+type factoryOptions struct {
+	Open          StepOptions
+	DriverOptions *driverOptions
+}
+
+func defaultFactoryOptions(driverName string, msgb StepEventMsgBuilder) *factoryOptions {
+	driverOptions := defaultDriverOptions(driverName, msgb)
+	return &factoryOptions{
+		Open:          *defaultStepOptions(msgb, StepSqlslogOpen, LevelInfo),
+		DriverOptions: driverOptions,
+	}
+}
+
 type Factory struct {
 	options    *options
 	driverName string

--- a/factory.go
+++ b/factory.go
@@ -28,7 +28,7 @@ func New(driverName, dsn string, opts ...Option) *Factory {
 
 func (f *Factory) newHandler() slog.Handler {
 	o := f.options.SlogOptions
-	return o.handlerFunc(o.logWriter, WrapHandlerOptions(&o.HandlerOptions))
+	return o.handlerFunc(o.logWriter, &o.HandlerOptions)
 }
 
 func (f *Factory) Handler() slog.Handler {

--- a/factory.go
+++ b/factory.go
@@ -41,7 +41,7 @@ func (f *Factory) Logger() *slog.Logger {
 }
 
 func (f *Factory) Open(ctx context.Context) (*sql.DB, error) {
-	stepLogger := newStepLogger(f.Logger(), &f.options.stepLoggerOptions)
+	stepLogger := newStepLogger(f.Logger(), f.options.stepLoggerOptions)
 	return open(ctx, f.driverName, f.dsn, stepLogger, f.options)
 }
 

--- a/factory.go
+++ b/factory.go
@@ -28,7 +28,7 @@ func New(driverName, dsn string, opts ...Option) *Factory {
 
 func (f *Factory) newHandler() slog.Handler {
 	o := f.options.SlogOptions
-	return o.handlerFunc(o.logWriter, WrapHandlerOptions(o.handlerOptions))
+	return o.handlerFunc(o.logWriter, WrapHandlerOptions(&o.HandlerOptions))
 }
 
 func (f *Factory) Handler() slog.Handler {

--- a/factory.go
+++ b/factory.go
@@ -26,9 +26,14 @@ func New(driverName, dsn string, opts ...Option) *Factory {
 	}
 }
 
+func (f *Factory) newHandler() slog.Handler {
+	o := f.options.SlogOptions
+	return o.handlerFunc(o.logWriter, WrapHandlerOptions(o.handlerOptions))
+}
+
 func (f *Factory) Handler() slog.Handler {
 	if f.handler == nil {
-		f.handler = f.options.SlogOptions.newHandler()
+		f.handler = f.newHandler()
 	}
 	return f.handler
 }

--- a/factory.go
+++ b/factory.go
@@ -28,10 +28,10 @@ func (f *Factory) Open(ctx context.Context) (*sql.DB, error) {
 		durationKey:  f.options.durationKey,
 		durationType: f.options.durationType,
 	})
-	return open(ctx, f.driverName, f.dsn, logger, &f.options.sqlslogOptions)
+	return open(ctx, f.driverName, f.dsn, logger, &f.options.factoryOptions)
 }
 
-func open(ctx context.Context, driverName, dsn string, logger *stepLogger, options *sqlslogOptions) (*sql.DB, error) {
+func open(ctx context.Context, driverName, dsn string, logger *stepLogger, options *factoryOptions) (*sql.DB, error) {
 	lg := logger.With(
 		slog.String("driver", driverName),
 		slog.String("dsn", dsn),

--- a/factory.go
+++ b/factory.go
@@ -36,12 +36,12 @@ func (f *Factory) Logger() *slog.Logger {
 }
 
 func (f *Factory) Open(ctx context.Context) (*sql.DB, error) {
-	logger := newStepLogger(&stepLoggerOptions{
+	stepLogger := newStepLogger(&stepLoggerOptions{
 		logger:       f.options.logger,
 		durationKey:  f.options.durationKey,
 		durationType: f.options.durationType,
 	})
-	return open(ctx, f.driverName, f.dsn, logger, f.options)
+	return open(ctx, f.driverName, f.dsn, stepLogger, f.options)
 }
 
 func open(ctx context.Context, driverName, dsn string, logger *stepLogger, options *options) (*sql.DB, error) {

--- a/factory.go
+++ b/factory.go
@@ -18,7 +18,12 @@ type Factory struct {
 
 func New(driverName, dsn string, opts ...Option) *Factory {
 	options := newOptions(driverName, opts...)
-	return &Factory{driverName: driverName, dsn: dsn, options: options}
+	return &Factory{
+		driverName: driverName,
+		dsn:        dsn,
+		options:    options,
+		handler:    options.SlogOptions.handler,
+	}
 }
 
 func (f *Factory) Handler() slog.Handler {

--- a/factory.go
+++ b/factory.go
@@ -36,8 +36,9 @@ func (f *Factory) Logger() *slog.Logger {
 }
 
 func (f *Factory) Open(ctx context.Context) (*sql.DB, error) {
+	logger := f.Logger()
 	stepLogger := newStepLogger(&stepLoggerOptions{
-		logger:       f.options.logger,
+		logger:       logger,
 		durationKey:  f.options.durationKey,
 		durationType: f.options.durationType,
 	})

--- a/factory.go
+++ b/factory.go
@@ -1,0 +1,31 @@
+package sqlslog
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+)
+
+type Factory struct {
+	options    *options
+	driverName string
+	dsn        string
+}
+
+func New(driverName, dsn string, opts ...Option) *Factory {
+	options := newOptions(driverName, opts...)
+	return &Factory{driverName: driverName, dsn: dsn, options: options}
+}
+
+func (f *Factory) Logger() *slog.Logger {
+	return f.options.logger
+}
+
+func (f *Factory) Open(ctx context.Context) (*sql.DB, error) {
+	logger := newStepLogger(&stepLoggerOptions{
+		logger:       f.options.logger,
+		durationKey:  f.options.durationKey,
+		durationType: f.options.durationType,
+	})
+	return open(ctx, f.driverName, f.dsn, logger, &f.options.sqlslogOptions)
+}

--- a/factory.go
+++ b/factory.go
@@ -41,12 +41,7 @@ func (f *Factory) Logger() *slog.Logger {
 }
 
 func (f *Factory) Open(ctx context.Context) (*sql.DB, error) {
-	logger := f.Logger()
-	stepLogger := newStepLogger(&stepLoggerOptions{
-		logger:       logger,
-		durationKey:  f.options.durationKey,
-		durationType: f.options.durationType,
-	})
+	stepLogger := newStepLogger(f.Logger(), &f.options.stepLoggerOptions)
 	return open(ctx, f.driverName, f.dsn, stepLogger, f.options)
 }
 

--- a/id_gen_example_test.go
+++ b/id_gen_example_test.go
@@ -3,9 +3,7 @@ package sqlslog_test
 import (
 	"context"
 	cryptorand "crypto/rand"
-	"log/slog"
 	mathrandv2 "math/rand/v2"
-	"os"
 
 	sqlslog "github.com/akm/sql-slog"
 	// _ "github.com/mattn/go-sqlite3"
@@ -18,9 +16,8 @@ func ExampleIDGenerator() {
 		8,
 	)
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	db, _ := sqlslog.Open(context.TODO(), "sqlite3", "file::memory:?cache=shared",
-		sqlslog.Logger(logger),
+	db, _, _ := sqlslog.Open(context.TODO(), "sqlite3", "file::memory:?cache=shared",
+		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
 		sqlslog.IDGenerator(idGen),
 	)
 	defer db.Close()
@@ -33,9 +30,8 @@ func ExampleRandIntIDGenerator() {
 		8,
 	)
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	db, _ := sqlslog.Open(context.TODO(), "sqlite3", "file::memory:?cache=shared",
-		sqlslog.Logger(logger),
+	db, _, _ := sqlslog.Open(context.TODO(), "sqlite3", "file::memory:?cache=shared",
+		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
 		sqlslog.IDGenerator(idGen),
 	)
 	defer db.Close()
@@ -51,9 +47,8 @@ func ExampleIDGenErrorSuppressor() {
 		func(error) string { return "recovered" },
 	)
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	db, _ := sqlslog.Open(context.TODO(), "sqlite3", "file::memory:?cache=shared",
-		sqlslog.Logger(logger),
+	db, _, _ := sqlslog.Open(context.TODO(), "sqlite3", "file::memory:?cache=shared",
+		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
 		sqlslog.IDGenerator(idGen),
 	)
 	defer db.Close()

--- a/level.go
+++ b/level.go
@@ -1,8 +1,10 @@
 package sqlslog
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 )
 
 // Level is the log level for sqlslog.
@@ -47,6 +49,33 @@ func (l Level) String() string {
 // Level returns the slog.Level.
 func (l Level) Level() slog.Level {
 	return slog.Level(l)
+}
+
+var stringToLevel = map[string]Level{
+	"VERBOSE": LevelVerbose,
+	"TRACE":   LevelTrace,
+	"DEBUG":   LevelDebug,
+	"INFO":    LevelInfo,
+	"WARN":    LevelWarn,
+	"ERROR":   LevelError,
+}
+
+var ErrUnknownLevel = errors.New("unknown level")
+
+func ParseLevel(s string) (Level, error) {
+	lv, ok := stringToLevel[strings.ToUpper(s)]
+	if !ok {
+		return 0, fmt.Errorf("%w: %q", ErrUnknownLevel, s)
+	}
+	return lv, nil
+}
+
+func ParseLevelWithDefault(s string, def Level) Level {
+	lv, err := ParseLevel(s)
+	if err != nil {
+		return def
+	}
+	return lv
 }
 
 // ReplaceLevelAttr replaces the log level as sqlslog.Level with its string representation.

--- a/level_test.go
+++ b/level_test.go
@@ -42,3 +42,86 @@ func TestLevelString(t *testing.T) {
 		})
 	}
 }
+
+func TestParseLevel(t *testing.T) {
+	t.Parallel()
+	t.Run("Valid case", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name string
+			in   string
+			want Level
+		}{
+			{name: "LevelVerbose", in: "VERBOSE", want: LevelVerbose},
+			{name: "LevelTrace", in: "TRACE", want: LevelTrace},
+			{name: "LevelDebug", in: "DEBUG", want: LevelDebug},
+			{name: "LevelInfo", in: "INFO", want: LevelInfo},
+			{name: "LevelWarn", in: "WARN", want: LevelWarn},
+			{name: "LevelError", in: "ERROR", want: LevelError},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				if got, err := ParseLevel(tt.in); err != nil || got != tt.want {
+					t.Errorf("ParseLevel() = %v, %v, want %v, true", got, err, tt.want)
+				}
+			})
+		}
+	})
+	t.Run("Unknown level", func(t *testing.T) {
+		t.Parallel()
+		tests := []string{"", "UNKNOWN", "TRACE+", "TRACE-1", "TRACE+1", "TRACE+1+1"}
+		for _, in := range tests {
+			t.Run(in, func(t *testing.T) {
+				t.Parallel()
+				lv, err := ParseLevel(in)
+				if err == nil {
+					t.Fatal("Expected non-nil")
+				}
+				if lv != 0 {
+					t.Fatalf("Expected 0, got %v", lv)
+				}
+			})
+		}
+	})
+}
+
+func TestParseLevelWithDefault(t *testing.T) {
+	t.Parallel()
+	t.Run("Valid case", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name string
+			in   string
+			want Level
+		}{
+			{name: "LevelVerbose", in: "VERBOSE", want: LevelVerbose},
+			{name: "LevelTrace", in: "TRACE", want: LevelTrace},
+			{name: "LevelDebug", in: "DEBUG", want: LevelDebug},
+			{name: "LevelInfo", in: "INFO", want: LevelInfo},
+			{name: "LevelWarn", in: "WARN", want: LevelWarn},
+			{name: "LevelError", in: "ERROR", want: LevelError},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				if got := ParseLevelWithDefault(tt.in, LevelError); got != tt.want {
+					t.Errorf("ParseLevelWithDefault() = %v, want %v", got, tt.want)
+				}
+			})
+		}
+	})
+	t.Run("Unknown level", func(t *testing.T) {
+		t.Parallel()
+		tests := []string{"", "UNKNOWN", "TRACE+", "TRACE-1", "TRACE+1", "TRACE+1+1"}
+		for _, in := range tests {
+			t.Run(in, func(t *testing.T) {
+				t.Parallel()
+				lv := ParseLevelWithDefault(in, LevelError)
+				if lv != LevelError {
+					t.Fatalf("Expected LevelError, got %v", lv)
+				}
+			})
+		}
+	})
+}

--- a/mock_driver_test.go
+++ b/mock_driver_test.go
@@ -1,0 +1,40 @@
+package sqlslog_test
+
+import (
+	"database/sql"
+	"database/sql/driver"
+)
+
+type MockDriver struct {
+	OpenResult driver.Conn
+	OpenError  error
+}
+
+func (m *MockDriver) Open(name string) (driver.Conn, error) {
+	return m.OpenResult, m.OpenError
+}
+
+var (
+	mockDriver driver.Driver = &MockDriver{}
+)
+
+type MockConn struct {
+}
+
+func (m *MockConn) Begin() (driver.Tx, error) {
+	return nil, nil
+}
+
+func (m *MockConn) Close() error {
+	return nil
+}
+
+func (m *MockConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, nil
+}
+
+var _ driver.Conn = (*MockConn)(nil)
+
+func init() {
+	sql.Register("mock", mockDriver)
+}

--- a/mock_driver_test.go
+++ b/mock_driver_test.go
@@ -10,31 +10,28 @@ type MockDriver struct {
 	OpenError  error
 }
 
-func (m *MockDriver) Open(name string) (driver.Conn, error) {
+func (m *MockDriver) Open(string) (driver.Conn, error) {
 	return m.OpenResult, m.OpenError
 }
 
-var (
-	mockDriver driver.Driver = &MockDriver{}
-)
+var mockDriver driver.Driver = &MockDriver{}
 
-type MockConn struct {
-}
+type MockConn struct{}
 
 func (m *MockConn) Begin() (driver.Tx, error) {
-	return nil, nil
+	return nil, nil // nolint: nilnil
 }
 
 func (m *MockConn) Close() error {
 	return nil
 }
 
-func (m *MockConn) Prepare(query string) (driver.Stmt, error) {
-	return nil, nil
+func (m *MockConn) Prepare(string) (driver.Stmt, error) {
+	return nil, nil // nolint: nilnil
 }
 
 var _ driver.Conn = (*MockConn)(nil)
 
-func init() {
+func init() { // nolint: gochecknoinits
 	sql.Register("mock", mockDriver)
 }

--- a/open.go
+++ b/open.go
@@ -5,19 +5,6 @@ import (
 	"database/sql"
 )
 
-type factoryOptions struct {
-	Open          StepOptions
-	DriverOptions *driverOptions
-}
-
-func defaultFactoryOptions(driverName string, msgb StepEventMsgBuilder) *factoryOptions {
-	driverOptions := defaultDriverOptions(driverName, msgb)
-	return &factoryOptions{
-		Open:          *defaultStepOptions(msgb, StepSqlslogOpen, LevelInfo),
-		DriverOptions: driverOptions,
-	}
-}
-
 /*
 Open opens a database specified by its driver name and a driver-specific data source name,
 and returns a new database handle with logging capabilities.

--- a/open.go
+++ b/open.go
@@ -42,14 +42,7 @@ See the following example for usage:
 [sql.Open]: https://pkg.go.dev/database/sql#Open
 */
 func Open(ctx context.Context, driverName, dsn string, opts ...Option) (*sql.DB, error) { // nolint:funlen
-	options := newOptions(driverName, opts...)
-	logger := newStepLogger(&stepLoggerOptions{
-		logger:       options.logger,
-		durationKey:  options.durationKey,
-		durationType: options.durationType,
-	})
-
-	return open(ctx, driverName, dsn, logger, &options.sqlslogOptions)
+	return New(driverName, dsn, opts...).Open(ctx)
 }
 
 func open(ctx context.Context, driverName, dsn string, logger *stepLogger, options *sqlslogOptions) (*sql.DB, error) {

--- a/open.go
+++ b/open.go
@@ -3,8 +3,6 @@ package sqlslog
 import (
 	"context"
 	"database/sql"
-	"database/sql/driver"
-	"log/slog"
 )
 
 type sqlslogOptions struct {
@@ -43,50 +41,4 @@ See the following example for usage:
 */
 func Open(ctx context.Context, driverName, dsn string, opts ...Option) (*sql.DB, error) { // nolint:funlen
 	return New(driverName, dsn, opts...).Open(ctx)
-}
-
-func open(ctx context.Context, driverName, dsn string, logger *stepLogger, options *sqlslogOptions) (*sql.DB, error) {
-	lg := logger.With(
-		slog.String("driver", driverName),
-		slog.String("dsn", dsn),
-	)
-
-	var db *sql.DB
-	err := ignoreAttr(lg.Step(ctx, &options.Open, func() (*slog.Attr, error) {
-		var err error
-		db, err = openWithDriver(driverName, dsn, logger, options.DriverOptions)
-		return nil, err
-	}))
-	if err != nil {
-		return nil, err
-	}
-	return db, nil
-}
-
-func openWithDriver(driverName, dsn string, logger *stepLogger, driverOptions *driverOptions) (*sql.DB, error) {
-	db, err := sql.Open(driverName, dsn)
-	if err != nil {
-		return nil, err
-	}
-	// This db is not used directly, but it is used to get the driver.
-
-	drv := wrapDriver(db.Driver(), logger, driverOptions)
-
-	return openWithWrappedDriver(drv, dsn, logger, driverOptions)
-}
-
-func openWithWrappedDriver(drv driver.Driver, dsn string, logger *stepLogger, driverOptions *driverOptions) (*sql.DB, error) {
-	var origConnector driver.Connector
-
-	if dc, ok := drv.(driver.DriverContext); ok {
-		connector, err := dc.OpenConnector(dsn)
-		if err != nil {
-			return nil, err
-		}
-		origConnector = connector
-	} else {
-		origConnector = &dsnConnector{dsn: dsn, driver: drv}
-	}
-
-	return sql.OpenDB(wrapConnector(origConnector, logger, driverOptions.ConnectorOptions)), nil
 }

--- a/open.go
+++ b/open.go
@@ -5,14 +5,14 @@ import (
 	"database/sql"
 )
 
-type sqlslogOptions struct {
+type factoryOptions struct {
 	Open          StepOptions
 	DriverOptions *driverOptions
 }
 
-func defaultSqlslogOptions(driverName string, msgb StepEventMsgBuilder) *sqlslogOptions {
+func defaultFactoryOptions(driverName string, msgb StepEventMsgBuilder) *factoryOptions {
 	driverOptions := defaultDriverOptions(driverName, msgb)
-	return &sqlslogOptions{
+	return &factoryOptions{
 		Open:          *defaultStepOptions(msgb, StepSqlslogOpen, LevelInfo),
 		DriverOptions: driverOptions,
 	}

--- a/open.go
+++ b/open.go
@@ -3,6 +3,7 @@ package sqlslog
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 )
 
 /*
@@ -26,6 +27,11 @@ See the following example for usage:
 
 [sql.Open]: https://pkg.go.dev/database/sql#Open
 */
-func Open(ctx context.Context, driverName, dsn string, opts ...Option) (*sql.DB, error) { // nolint:funlen
-	return New(driverName, dsn, opts...).Open(ctx)
+func Open(ctx context.Context, driverName, dsn string, opts ...Option) (*sql.DB, *slog.Logger, error) { // nolint:funlen
+	factory := New(driverName, dsn, opts...)
+	db, err := factory.Open(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return db, factory.Logger(), nil
 }

--- a/open_example_test.go
+++ b/open_example_test.go
@@ -3,7 +3,6 @@ package sqlslog_test
 import (
 	"context"
 	"log/slog"
-	"os"
 
 	sqlslog "github.com/akm/sql-slog"
 	// _ "github.com/mattn/go-sqlite3"
@@ -12,32 +11,31 @@ import (
 func ExampleOpen() {
 	dsn := "file::memory:?cache=shared"
 	ctx := context.TODO()
-	db, err := sqlslog.Open(ctx, "sqlite3", dsn)
+	db, logger, err := sqlslog.Open(ctx, "sqlite3", dsn)
 	if err != nil {
 		// Handle error
 	}
 	defer db.Close()
 	// Use db as a regular *sql.DB
+	logger.InfoContext(ctx, "Hello, World!")
 }
 
 func ExampleOpen_withLevel() {
 	dsn := "file::memory:?cache=shared"
 	ctx := context.TODO()
-	logger := slog.New(sqlslog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: sqlslog.LevelTrace,
-	}))
-	db, _ := sqlslog.Open(ctx, "sqlite3", dsn, sqlslog.Logger(logger))
+	db, _, _ := sqlslog.Open(ctx, "sqlite3", dsn,
+		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
+		sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelTrace}),
+	)
 	defer db.Close()
 }
 
 func ExampleOpen_withStmtQueryContext() {
 	dsn := "file::memory:?cache=shared"
 	ctx := context.TODO()
-	logger := slog.New(sqlslog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: sqlslog.LevelTrace,
-	}))
-	db, _ := sqlslog.Open(ctx, "sqlite3", dsn,
-		sqlslog.Logger(logger),
+	db, _, _ := sqlslog.Open(ctx, "sqlite3", dsn,
+		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
+		sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelTrace}),
 		sqlslog.StmtQueryContext(func(o *sqlslog.StepOptions) {
 			o.SetLevel(sqlslog.LevelDebug)
 		}),

--- a/open_example_test.go
+++ b/open_example_test.go
@@ -2,7 +2,6 @@ package sqlslog_test
 
 import (
 	"context"
-	"log/slog"
 
 	sqlslog "github.com/akm/sql-slog"
 	// _ "github.com/mattn/go-sqlite3"
@@ -25,7 +24,7 @@ func ExampleOpen_withLevel() {
 	ctx := context.TODO()
 	db, _, _ := sqlslog.Open(ctx, "sqlite3", dsn,
 		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
-		sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelTrace}),
+		sqlslog.LogLevel(sqlslog.LevelTrace),
 	)
 	defer db.Close()
 }
@@ -35,7 +34,7 @@ func ExampleOpen_withStmtQueryContext() {
 	ctx := context.TODO()
 	db, _, _ := sqlslog.Open(ctx, "sqlite3", dsn,
 		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
-		sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelTrace}),
+		sqlslog.LogLevel(sqlslog.LevelTrace),
 		sqlslog.StmtQueryContext(func(o *sqlslog.StepOptions) {
 			o.SetLevel(sqlslog.LevelDebug)
 		}),

--- a/open_example_test.go
+++ b/open_example_test.go
@@ -23,7 +23,6 @@ func ExampleOpen_withLevel() {
 	dsn := "file::memory:?cache=shared"
 	ctx := context.TODO()
 	db, _, _ := sqlslog.Open(ctx, "sqlite3", dsn,
-		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
 		sqlslog.LogLevel(sqlslog.LevelTrace),
 	)
 	defer db.Close()
@@ -33,7 +32,6 @@ func ExampleOpen_withStmtQueryContext() {
 	dsn := "file::memory:?cache=shared"
 	ctx := context.TODO()
 	db, _, _ := sqlslog.Open(ctx, "sqlite3", dsn,
-		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
 		sqlslog.LogLevel(sqlslog.LevelTrace),
 		sqlslog.StmtQueryContext(func(o *sqlslog.StepOptions) {
 			o.SetLevel(sqlslog.LevelDebug)

--- a/open_test.go
+++ b/open_test.go
@@ -53,7 +53,7 @@ func TestOpenWithDriver(t *testing.T) {
 		t.Parallel()
 		t.Run("DriverContext", func(t *testing.T) {
 			drv := newErrorDriverContext(errors.New("unknown error"))
-			stepLogger := newStepLogger(slog.New(slog.NewJSONHandler(nil, nil)), newStepLoggerOptions())
+			stepLogger := newStepLogger(slog.New(slog.NewJSONHandler(nil, nil)), defaultStepLoggerOptions())
 			if _, err := openWithWrappedDriver(drv, "invalid-dsn", stepLogger, nil); err == nil {
 				t.Fatal("Expected error")
 			}

--- a/open_test.go
+++ b/open_test.go
@@ -1,7 +1,6 @@
 package sqlslog
 
 import (
-	"bytes"
 	"context"
 	"database/sql/driver"
 	"errors"
@@ -12,10 +11,8 @@ import (
 func TestOpen(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
-	buf := bytes.NewBuffer(nil)
-	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	db, err := Open(ctx, "invalid-driver", "", Logger(logger))
+	db, _, err := Open(ctx, "invalid-driver", "")
 	if err == nil {
 		t.Fatal("Expected error")
 	}

--- a/open_test.go
+++ b/open_test.go
@@ -53,7 +53,7 @@ func TestOpenWithDriver(t *testing.T) {
 		t.Parallel()
 		t.Run("DriverContext", func(t *testing.T) {
 			drv := newErrorDriverContext(errors.New("unknown error"))
-			stepLogger := newStepLogger(newStepLoggerOptions(slog.New(slog.NewJSONHandler(nil, nil))))
+			stepLogger := newStepLogger(slog.New(slog.NewJSONHandler(nil, nil)), newStepLoggerOptions())
 			if _, err := openWithWrappedDriver(drv, "invalid-dsn", stepLogger, nil); err == nil {
 				t.Fatal("Expected error")
 			}

--- a/options.go
+++ b/options.go
@@ -1,7 +1,7 @@
 package sqlslog
 
 type options struct {
-	*stepLoggerOptions
+	stepLoggerOptions
 	DriverOptions *driverOptions
 	SlogOptions   *slogOptions
 	Open          StepOptions

--- a/options.go
+++ b/options.go
@@ -6,7 +6,7 @@ import (
 
 type options struct {
 	stepLoggerOptions
-	sqlslogOptions
+	factoryOptions
 }
 
 func newDefaultOptions(driverName string, msgb StepEventMsgBuilder) *options {
@@ -16,7 +16,7 @@ func newDefaultOptions(driverName string, msgb StepEventMsgBuilder) *options {
 			durationKey:  DurationKeyDefault,
 			durationType: DurationNanoSeconds,
 		},
-		sqlslogOptions: *defaultSqlslogOptions(driverName, msgb),
+		factoryOptions: *defaultFactoryOptions(driverName, msgb),
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -6,7 +6,9 @@ import (
 
 type options struct {
 	stepLoggerOptions
-	factoryOptions
+	DriverOptions *driverOptions
+	SlogOptions   *slogOptions
+	Open          StepOptions
 }
 
 func newDefaultOptions(driverName string, msgb StepEventMsgBuilder) *options {
@@ -16,7 +18,9 @@ func newDefaultOptions(driverName string, msgb StepEventMsgBuilder) *options {
 			durationKey:  DurationKeyDefault,
 			durationType: DurationNanoSeconds,
 		},
-		factoryOptions: *defaultFactoryOptions(driverName, msgb),
+		DriverOptions: defaultDriverOptions(driverName, msgb),
+		SlogOptions:   defaultSlogOptions(),
+		Open:          *defaultStepOptions(msgb, StepSqlslogOpen, LevelInfo),
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -1,9 +1,5 @@
 package sqlslog
 
-import (
-	"log/slog"
-)
-
 type options struct {
 	stepLoggerOptions
 	DriverOptions *driverOptions
@@ -14,7 +10,6 @@ type options struct {
 func newDefaultOptions(driverName string, msgb StepEventMsgBuilder) *options {
 	return &options{
 		stepLoggerOptions: stepLoggerOptions{
-			logger:       slog.Default(),
 			durationKey:  DurationKeyDefault,
 			durationType: DurationNanoSeconds,
 		},
@@ -39,14 +34,6 @@ func newOptions(driverName string, opts ...Option) *options {
 		opt(o)
 	}
 	return o
-}
-
-// Logger sets the slog.Logger to be used.
-// If not set, the default is slog.Default().
-func Logger(logger *slog.Logger) Option {
-	return func(o *options) {
-		o.stepLoggerOptions.logger = logger
-	}
 }
 
 // Set the options for Conn.Begin.

--- a/options.go
+++ b/options.go
@@ -1,7 +1,7 @@
 package sqlslog
 
 type options struct {
-	stepLoggerOptions
+	*stepLoggerOptions
 	DriverOptions *driverOptions
 	SlogOptions   *slogOptions
 	Open          StepOptions
@@ -9,13 +9,10 @@ type options struct {
 
 func newDefaultOptions(driverName string, msgb StepEventMsgBuilder) *options {
 	return &options{
-		stepLoggerOptions: stepLoggerOptions{
-			durationKey:  DurationKeyDefault,
-			durationType: DurationNanoSeconds,
-		},
-		DriverOptions: defaultDriverOptions(driverName, msgb),
-		SlogOptions:   defaultSlogOptions(),
-		Open:          *defaultStepOptions(msgb, StepSqlslogOpen, LevelInfo),
+		stepLoggerOptions: defaultStepLoggerOptions(),
+		DriverOptions:     defaultDriverOptions(driverName, msgb),
+		SlogOptions:       defaultSlogOptions(),
+		Open:              *defaultStepOptions(msgb, StepSqlslogOpen, LevelInfo),
 	}
 }
 

--- a/options_example_test.go
+++ b/options_example_test.go
@@ -2,19 +2,19 @@ package sqlslog_test
 
 import (
 	"context"
-	"log/slog"
-	"os"
 
 	sqlslog "github.com/akm/sql-slog"
 	// _ "github.com/mattn/go-sqlite3"
 )
 
-func ExampleLogger() {
+func ExampleHandlerFunc() {
 	dsn := "file::memory:?cache=shared"
 	ctx := context.TODO()
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	db, _ := sqlslog.Open(ctx, "sqlite3", dsn, sqlslog.Logger(logger))
+	db, logger, _ := sqlslog.Open(ctx, "sqlite3", dsn,
+		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
+	)
 	defer db.Close()
+	logger.InfoContext(ctx, "Hello, World!")
 }
 
 func ExampleSetStepEventMsgBuilder() {
@@ -23,7 +23,8 @@ func ExampleSetStepEventMsgBuilder() {
 	})
 	dsn := "file::memory:?cache=shared"
 	ctx := context.TODO()
-	logger := slog.New(sqlslog.NewJSONHandler(os.Stdout, nil))
-	db, _ := sqlslog.Open(ctx, "sqlite3", dsn, sqlslog.Logger(logger))
+	db, _, _ := sqlslog.Open(ctx, "sqlite3", dsn,
+		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
+	)
 	defer db.Close()
 }

--- a/rows_test.go
+++ b/rows_test.go
@@ -90,7 +90,7 @@ func TestRowsNextResultSet(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	logger := slog.New(NewJSONHandler(buf, nil))
 	rowsOptions := defaultRowsOptions(StepEventMsgWithoutEventName)
-	wrapped := wrapRows(rows, newStepLogger(logger, newStepLoggerOptions()), rowsOptions)
+	wrapped := wrapRows(rows, newStepLogger(logger, defaultStepLoggerOptions()), rowsOptions)
 	wrappedRNRS, ok := wrapped.(driver.RowsNextResultSet)
 	if !ok {
 		t.Fatal("Expected true")

--- a/rows_test.go
+++ b/rows_test.go
@@ -36,7 +36,7 @@ func (m *mockRows) Next([]driver.Value) error {
 
 func TestWithMockRows(t *testing.T) {
 	t.Parallel()
-	wrapped := &rowsWrapper{original: &mockRows{}, logger: newStepLogger(nil)}
+	wrapped := &rowsWrapper{original: &mockRows{}, logger: newStepLogger(slog.Default(), nil)}
 	t.Run("ColumnTypeScanType", func(t *testing.T) {
 		t.Parallel()
 		res := wrapped.ColumnTypeScanType(0)
@@ -90,7 +90,7 @@ func TestRowsNextResultSet(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	logger := slog.New(NewJSONHandler(buf, nil))
 	rowsOptions := defaultRowsOptions(StepEventMsgWithoutEventName)
-	wrapped := wrapRows(rows, newStepLogger(newStepLoggerOptions(logger)), rowsOptions)
+	wrapped := wrapRows(rows, newStepLogger(logger, newStepLoggerOptions()), rowsOptions)
 	wrappedRNRS, ok := wrapped.(driver.RowsNextResultSet)
 	if !ok {
 		t.Fatal("Expected true")

--- a/rows_test.go
+++ b/rows_test.go
@@ -36,7 +36,7 @@ func (m *mockRows) Next([]driver.Value) error {
 
 func TestWithMockRows(t *testing.T) {
 	t.Parallel()
-	wrapped := &rowsWrapper{original: &mockRows{}, logger: newStepLogger(slog.Default(), nil)}
+	wrapped := &rowsWrapper{original: &mockRows{}, logger: newStepLogger(slog.Default(), defaultStepLoggerOptions())}
 	t.Run("ColumnTypeScanType", func(t *testing.T) {
 		t.Parallel()
 		res := wrapped.ColumnTypeScanType(0)

--- a/slog.go
+++ b/slog.go
@@ -23,6 +23,9 @@ func defaultSlogOptions() *slogOptions {
 
 // Handler sets the slog.Handler to be used.
 // If not set, the default is created by HandlerFunc, Writer, SlogOptions.
+// If you set this option, HandlerFunc, Writer, SlogOptions will be ignored.
+// WARNING: If given handler is created without ReplaceAttr options,
+// LevelTrace and LevelVerbose will be logged as DEBUG-4 and DEBUG-8.
 func Handler(handler slog.Handler) Option {
 	return func(o *options) { o.SlogOptions.handler = handler }
 }
@@ -69,14 +72,14 @@ func LogReplaceAttr(f func([]string, slog.Attr) slog.Attr) Option {
 // with custom options for sqlslog.
 // See [WrapHandlerOptions] for details on the options.
 func NewJSONHandler(w io.Writer, opts *slog.HandlerOptions) slog.Handler {
-	return slog.NewJSONHandler(w, opts)
+	return slog.NewJSONHandler(w, WrapHandlerOptions(opts))
 }
 
 // NewTextHandler returns a new Text handler using [slog.NewTextHandler]
 // with custom options for sqlslog.
 // See [WrapHandlerOptions] for details on the options.
 func NewTextHandler(w io.Writer, opts *slog.HandlerOptions) slog.Handler {
-	return slog.NewTextHandler(w, opts)
+	return slog.NewTextHandler(w, WrapHandlerOptions(opts))
 }
 
 // WrapHandlerOptions wraps the options with custom options for sqlslog.

--- a/slog.go
+++ b/slog.go
@@ -7,17 +7,17 @@ import (
 )
 
 type slogOptions struct {
-	handler        slog.Handler
-	handlerFunc    func(io.Writer, *slog.HandlerOptions) slog.Handler
-	logWriter      io.Writer
-	handlerOptions *slog.HandlerOptions
+	slog.HandlerOptions
+	handler     slog.Handler
+	handlerFunc func(io.Writer, *slog.HandlerOptions) slog.Handler
+	logWriter   io.Writer
 }
 
 func defaultSlogOptions() *slogOptions {
 	return &slogOptions{
 		handlerFunc:    NewTextHandler,
 		logWriter:      os.Stdout,
-		handlerOptions: &slog.HandlerOptions{},
+		HandlerOptions: slog.HandlerOptions{},
 	}
 }
 
@@ -42,7 +42,12 @@ func LogWriter(w io.Writer) Option {
 // HandlerOptions sets the options to be used for the slog.Handler.
 // If not set, the default is an empty [slog.HandlerOptions].
 func HandlerOptions(opts *slog.HandlerOptions) Option {
-	return func(o *options) { o.SlogOptions.handlerOptions = opts }
+	return func(o *options) {
+		if opts == nil {
+			opts = &slog.HandlerOptions{}
+		}
+		o.SlogOptions.HandlerOptions = *opts
+	}
 }
 
 // NewJSONHandler returns a new JSON handler using [slog.NewJSONHandler]

--- a/slog.go
+++ b/slog.go
@@ -7,17 +7,17 @@ import (
 )
 
 type slogOptions struct {
-	handler     slog.Handler
-	handlerFunc func(io.Writer, *slog.HandlerOptions) slog.Handler
-	writer      io.Writer
-	opts        *slog.HandlerOptions
+	handler        slog.Handler
+	handlerFunc    func(io.Writer, *slog.HandlerOptions) slog.Handler
+	logWriter      io.Writer
+	handlerOptions *slog.HandlerOptions
 }
 
 func defaultSlogOptions() *slogOptions {
 	return &slogOptions{
-		handlerFunc: NewTextHandler,
-		writer:      os.Stdout,
-		opts:        &slog.HandlerOptions{},
+		handlerFunc:    NewTextHandler,
+		logWriter:      os.Stdout,
+		handlerOptions: &slog.HandlerOptions{},
 	}
 }
 
@@ -25,7 +25,31 @@ func (o *slogOptions) newHandler() slog.Handler {
 	if o.handler != nil {
 		return o.handler
 	}
-	return o.handlerFunc(o.writer, WrapHandlerOptions(o.opts))
+	return o.handlerFunc(o.logWriter, WrapHandlerOptions(o.handlerOptions))
+}
+
+// Handler sets the slog.Handler to be used.
+// If not set, the default is created by HandlerFunc, Writer, SlogOptions.
+func Handler(handler slog.Handler) Option {
+	return func(o *options) { o.SlogOptions.handler = handler }
+}
+
+// HandlerFunc sets the function to create the slog.Handler.
+// If not set, the default is [NewTextHandler].
+func HandlerFunc(handlerFunc func(io.Writer, *slog.HandlerOptions) slog.Handler) Option {
+	return func(o *options) { o.SlogOptions.handlerFunc = handlerFunc }
+}
+
+// LogWriter sets the writer to be used for the slog.Handler.
+// If not set, the default is os.Stdout.
+func LogWriter(w io.Writer) Option {
+	return func(o *options) { o.SlogOptions.logWriter = w }
+}
+
+// HandlerOptions sets the options to be used for the slog.Handler.
+// If not set, the default is an empty [slog.HandlerOptions].
+func HandlerOptions(opts *slog.HandlerOptions) Option {
+	return func(o *options) { o.SlogOptions.handlerOptions = opts }
 }
 
 // NewJSONHandler returns a new JSON handler using [slog.NewJSONHandler]

--- a/slog.go
+++ b/slog.go
@@ -32,6 +32,8 @@ func Handler(handler slog.Handler) Option {
 
 // HandlerFunc sets the function to create the slog.Handler.
 // If not set, the default is [NewTextHandler].
+// WARNING: Unless given handlerFunc considers ReplaceAttr options like [NewJSONHandler] or [NewTextHandler] of sqlslog package,
+// LevelTrace and LevelVerbose will be logged as DEBUG-4 and DEBUG-8.
 func HandlerFunc(handlerFunc func(io.Writer, *slog.HandlerOptions) slog.Handler) Option {
 	return func(o *options) { o.SlogOptions.handlerFunc = handlerFunc }
 }

--- a/slog.go
+++ b/slog.go
@@ -56,10 +56,6 @@ func HandlerOptions(opts *slog.HandlerOptions) Option {
 // with custom options for sqlslog.
 // See [WrapHandlerOptions] for details on the options.
 func NewJSONHandler(w io.Writer, opts *slog.HandlerOptions) slog.Handler {
-	return newJSONHandler(w, opts)
-}
-
-func newJSONHandler(w io.Writer, opts *slog.HandlerOptions) *slog.JSONHandler {
 	return slog.NewJSONHandler(w, opts)
 }
 
@@ -67,10 +63,6 @@ func newJSONHandler(w io.Writer, opts *slog.HandlerOptions) *slog.JSONHandler {
 // with custom options for sqlslog.
 // See [WrapHandlerOptions] for details on the options.
 func NewTextHandler(w io.Writer, opts *slog.HandlerOptions) slog.Handler {
-	return newTextHandler(w, opts)
-}
-
-func newTextHandler(w io.Writer, opts *slog.HandlerOptions) *slog.TextHandler {
 	return slog.NewTextHandler(w, opts)
 }
 

--- a/slog.go
+++ b/slog.go
@@ -50,6 +50,21 @@ func HandlerOptions(opts *slog.HandlerOptions) Option {
 	}
 }
 
+// AddSource sets whether to add the source to the log.
+func AddSource(v bool) Option {
+	return func(o *options) { o.SlogOptions.AddSource = v }
+}
+
+// LogLevel sets the log level to be used.
+func LogLevel(v slog.Leveler) Option {
+	return func(o *options) { o.SlogOptions.Level = v }
+}
+
+// ReplaceAttr sets the function to replace the attributes.
+func LogReplaceAttr(f func([]string, slog.Attr) slog.Attr) Option {
+	return func(o *options) { o.SlogOptions.ReplaceAttr = f }
+}
+
 // NewJSONHandler returns a new JSON handler using [slog.NewJSONHandler]
 // with custom options for sqlslog.
 // See [WrapHandlerOptions] for details on the options.

--- a/slog.go
+++ b/slog.go
@@ -21,13 +21,6 @@ func defaultSlogOptions() *slogOptions {
 	}
 }
 
-func (o *slogOptions) newHandler() slog.Handler {
-	if o.handler != nil {
-		return o.handler
-	}
-	return o.handlerFunc(o.logWriter, WrapHandlerOptions(o.handlerOptions))
-}
-
 // Handler sets the slog.Handler to be used.
 // If not set, the default is created by HandlerFunc, Writer, SlogOptions.
 func Handler(handler slog.Handler) Option {

--- a/slog.go
+++ b/slog.go
@@ -3,7 +3,30 @@ package sqlslog
 import (
 	"io"
 	"log/slog"
+	"os"
 )
+
+type slogOptions struct {
+	handler     slog.Handler
+	handlerFunc func(io.Writer, *slog.HandlerOptions) slog.Handler
+	writer      io.Writer
+	opts        *slog.HandlerOptions
+}
+
+func defaultSlogOptions() *slogOptions {
+	return &slogOptions{
+		handlerFunc: NewTextHandler,
+		writer:      os.Stdout,
+		opts:        &slog.HandlerOptions{},
+	}
+}
+
+func (o *slogOptions) newHandler() slog.Handler {
+	if o.handler != nil {
+		return o.handler
+	}
+	return o.handlerFunc(o.writer, WrapHandlerOptions(o.opts))
+}
 
 // NewJSONHandler returns a new JSON handler using [slog.NewJSONHandler]
 // with custom options for sqlslog.

--- a/slog.go
+++ b/slog.go
@@ -60,7 +60,7 @@ func NewJSONHandler(w io.Writer, opts *slog.HandlerOptions) slog.Handler {
 }
 
 func newJSONHandler(w io.Writer, opts *slog.HandlerOptions) *slog.JSONHandler {
-	return slog.NewJSONHandler(w, WrapHandlerOptions(opts))
+	return slog.NewJSONHandler(w, opts)
 }
 
 // NewTextHandler returns a new Text handler using [slog.NewTextHandler]
@@ -71,7 +71,7 @@ func NewTextHandler(w io.Writer, opts *slog.HandlerOptions) slog.Handler {
 }
 
 func newTextHandler(w io.Writer, opts *slog.HandlerOptions) *slog.TextHandler {
-	return slog.NewTextHandler(w, WrapHandlerOptions(opts))
+	return slog.NewTextHandler(w, opts)
 }
 
 // WrapHandlerOptions wraps the options with custom options for sqlslog.

--- a/slog.go
+++ b/slog.go
@@ -8,14 +8,22 @@ import (
 // NewJSONHandler returns a new JSON handler using [slog.NewJSONHandler]
 // with custom options for sqlslog.
 // See [WrapHandlerOptions] for details on the options.
-func NewJSONHandler(w io.Writer, opts *slog.HandlerOptions) *slog.JSONHandler {
+func NewJSONHandler(w io.Writer, opts *slog.HandlerOptions) slog.Handler {
+	return newJSONHandler(w, opts)
+}
+
+func newJSONHandler(w io.Writer, opts *slog.HandlerOptions) *slog.JSONHandler {
 	return slog.NewJSONHandler(w, WrapHandlerOptions(opts))
 }
 
 // NewTextHandler returns a new Text handler using [slog.NewTextHandler]
 // with custom options for sqlslog.
 // See [WrapHandlerOptions] for details on the options.
-func NewTextHandler(w io.Writer, opts *slog.HandlerOptions) *slog.TextHandler {
+func NewTextHandler(w io.Writer, opts *slog.HandlerOptions) slog.Handler {
+	return newTextHandler(w, opts)
+}
+
+func newTextHandler(w io.Writer, opts *slog.HandlerOptions) *slog.TextHandler {
 	return slog.NewTextHandler(w, WrapHandlerOptions(opts))
 }
 

--- a/slog_example_test.go
+++ b/slog_example_test.go
@@ -2,28 +2,50 @@ package sqlslog_test
 
 import (
 	"context"
+	"log/slog"
 
 	sqlslog "github.com/akm/sql-slog"
 	// _ "github.com/mattn/go-sqlite3"
 )
 
+func removeTimeAndDuration(groups []string, a slog.Attr) slog.Attr {
+	if len(groups) == 0 {
+		switch a.Key {
+		case slog.TimeKey:
+			return slog.Attr{}
+		case "duration":
+			return slog.Attr{}
+		}
+	}
+	return a
+}
+
 func ExampleNewJSONHandler() {
-	dsn := "file::memory:?cache=shared"
+	dsn := "dummy-dsn"
 	ctx := context.TODO()
-	db, logger, _ := sqlslog.Open(ctx, "sqlite3", dsn,
+	db, logger, _ := sqlslog.Open(ctx, "mock", dsn,
 		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
-		sqlslog.LogLevel(sqlslog.LevelDebug),
+		sqlslog.LogReplaceAttr(removeTimeAndDuration),
 	)
 	defer db.Close()
 	logger.InfoContext(ctx, "Hello, World!")
+
+	// Output:
+	// {"level":"INFO","msg":"Open","driver":"mock","dsn":"dummy-dsn"}
+	// {"level":"INFO","msg":"Hello, World!"}
 }
 
 func ExampleNewTextHandler() {
-	dsn := "file::memory:?cache=shared"
+	dsn := "dummy-dsn"
 	ctx := context.TODO()
-	db, logger, _ := sqlslog.Open(ctx, "sqlite3", dsn,
+	db, logger, _ := sqlslog.Open(ctx, "mock", dsn,
 		sqlslog.HandlerFunc(sqlslog.NewTextHandler),
+		sqlslog.LogReplaceAttr(removeTimeAndDuration),
 	)
 	defer db.Close()
 	logger.InfoContext(ctx, "Hello, World!")
+
+	// Output:
+	// level=INFO msg=Open driver=mock dsn=dummy-dsn
+	// level=INFO msg="Hello, World!"
 }

--- a/slog_example_test.go
+++ b/slog_example_test.go
@@ -3,6 +3,7 @@ package sqlslog_test
 import (
 	"context"
 	"log/slog"
+	"os"
 
 	sqlslog "github.com/akm/sql-slog"
 	// _ "github.com/mattn/go-sqlite3"
@@ -48,4 +49,45 @@ func ExampleNewTextHandler() {
 	// Output:
 	// level=INFO msg=Open driver=mock dsn=dummy-dsn
 	// level=INFO msg="Hello, World!"
+}
+
+func ExampleHandler() {
+	// Normal slog.Handler with sqlslog.ReplaceLevelAttr knows how to show LevelTrace and LevelVerbose.
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		ReplaceAttr: sqlslog.MergeReplaceAttrs(
+			sqlslog.ReplaceLevelAttr,
+			removeTimeAndDuration, // for testing
+		),
+		Level: sqlslog.LevelVerbose,
+	})
+
+	dsn := "dummy-dsn"
+	ctx := context.TODO()
+
+	logger := sqlslog.New("mock", dsn, sqlslog.Handler(handler)).Logger()
+	logger.Log(ctx, slog.Level(sqlslog.LevelTrace), "Foo")
+	logger.Log(ctx, slog.Level(sqlslog.LevelVerbose), "Bar")
+
+	// Output:
+	// level=TRACE msg=Foo
+	// level=VERBOSE msg=Bar
+}
+
+func ExampleHandler_withoutReplaceLevelAttr() {
+	// Normal slog.Handler without sqlslog.ReplaceLevelAttr does not know how to show LevelTrace and LevelVerbose.
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		ReplaceAttr: removeTimeAndDuration,
+		Level:       sqlslog.LevelVerbose,
+	})
+
+	dsn := "dummy-dsn"
+	ctx := context.TODO()
+	logger := sqlslog.New("mock", dsn, sqlslog.Handler(handler)).Logger()
+
+	logger.Log(ctx, slog.Level(sqlslog.LevelTrace), "Foo")
+	logger.Log(ctx, slog.Level(sqlslog.LevelVerbose), "Bar")
+
+	// Output:
+	// level=DEBUG-4 msg=Foo
+	// level=DEBUG-8 msg=Bar
 }

--- a/slog_example_test.go
+++ b/slog_example_test.go
@@ -3,7 +3,6 @@ package sqlslog_test
 import (
 	"context"
 	"log/slog"
-	"os"
 
 	sqlslog "github.com/akm/sql-slog"
 	// _ "github.com/mattn/go-sqlite3"
@@ -12,17 +11,20 @@ import (
 func ExampleNewJSONHandler() {
 	dsn := "file::memory:?cache=shared"
 	ctx := context.TODO()
-	logger := slog.New(sqlslog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	}))
-	db, _ := sqlslog.Open(ctx, "sqlite3", dsn, sqlslog.Logger(logger))
+	db, logger, _ := sqlslog.Open(ctx, "sqlite3", dsn,
+		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
+		sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelDebug}),
+	)
 	defer db.Close()
+	logger.InfoContext(ctx, "Hello, World!")
 }
 
 func ExampleNewTextHandler() {
 	dsn := "file::memory:?cache=shared"
 	ctx := context.TODO()
-	logger := slog.New(sqlslog.NewTextHandler(os.Stdout, nil))
-	db, _ := sqlslog.Open(ctx, "sqlite3", dsn, sqlslog.Logger(logger))
+	db, logger, _ := sqlslog.Open(ctx, "sqlite3", dsn,
+		sqlslog.HandlerFunc(sqlslog.NewTextHandler),
+	)
 	defer db.Close()
+	logger.InfoContext(ctx, "Hello, World!")
 }

--- a/slog_example_test.go
+++ b/slog_example_test.go
@@ -2,7 +2,6 @@ package sqlslog_test
 
 import (
 	"context"
-	"log/slog"
 
 	sqlslog "github.com/akm/sql-slog"
 	// _ "github.com/mattn/go-sqlite3"
@@ -13,7 +12,7 @@ func ExampleNewJSONHandler() {
 	ctx := context.TODO()
 	db, logger, _ := sqlslog.Open(ctx, "sqlite3", dsn,
 		sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
-		sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelDebug}),
+		sqlslog.LogLevel(sqlslog.LevelDebug),
 	)
 	defer db.Close()
 	logger.InfoContext(ctx, "Hello, World!")

--- a/slog_test.go
+++ b/slog_test.go
@@ -94,3 +94,35 @@ func TestMergeReplaceAttrs(t *testing.T) {
 		}
 	})
 }
+
+func TestHandlerOptions(t *testing.T) {
+	t.Parallel()
+	t.Run("nil parameter", func(t *testing.T) {
+		t.Parallel()
+		o := HandlerOptions(nil)
+		if o == nil {
+			t.Errorf("want not nil, got nil")
+		}
+		opts := &options{SlogOptions: defaultSlogOptions()}
+		o(opts)
+	})
+	t.Run("one parameter", func(t *testing.T) {
+		t.Parallel()
+		o := HandlerOptions(&slog.HandlerOptions{})
+		if o == nil {
+			t.Errorf("want not nil, got nil")
+		}
+		opts := &options{SlogOptions: defaultSlogOptions()}
+		o(opts)
+	})
+}
+
+func TestAddSource(t *testing.T) {
+	t.Parallel()
+	o := AddSource(true)
+	if o == nil {
+		t.Errorf("want not nil, got nil")
+	}
+	opts := &options{SlogOptions: defaultSlogOptions()}
+	o(opts)
+}

--- a/step_logger.go
+++ b/step_logger.go
@@ -11,7 +11,7 @@ type stepLoggerOptions struct {
 	durationType DurationType
 }
 
-func newStepLoggerOptions() *stepLoggerOptions {
+func defaultStepLoggerOptions() *stepLoggerOptions {
 	return &stepLoggerOptions{
 		durationKey:  DurationKeyDefault,
 		durationType: DurationNanoSeconds,
@@ -25,7 +25,7 @@ type stepLogger struct {
 
 func newStepLogger(logger *slog.Logger, opts *stepLoggerOptions) *stepLogger {
 	if opts == nil {
-		opts = newStepLoggerOptions()
+		opts = defaultStepLoggerOptions()
 	}
 	return &stepLogger{
 		Logger:       logger,

--- a/step_logger.go
+++ b/step_logger.go
@@ -7,14 +7,12 @@ import (
 )
 
 type stepLoggerOptions struct {
-	logger       *slog.Logger
 	durationKey  string
 	durationType DurationType
 }
 
-func newStepLoggerOptions(logger *slog.Logger) *stepLoggerOptions {
+func newStepLoggerOptions() *stepLoggerOptions {
 	return &stepLoggerOptions{
-		logger:       logger,
 		durationKey:  DurationKeyDefault,
 		durationType: DurationNanoSeconds,
 	}
@@ -25,16 +23,12 @@ type stepLogger struct {
 	durationAttr func(d time.Duration) slog.Attr
 }
 
-func newStepLogger(opts *stepLoggerOptions) *stepLogger {
+func newStepLogger(logger *slog.Logger, opts *stepLoggerOptions) *stepLogger {
 	if opts == nil {
-		opts = newStepLoggerOptions(nil)
-	}
-	rawLogger := opts.logger
-	if rawLogger == nil {
-		rawLogger = slog.Default()
+		opts = newStepLoggerOptions()
 	}
 	return &stepLogger{
-		Logger:       rawLogger,
+		Logger:       logger,
 		durationAttr: durationAttrFunc(opts.durationKey, opts.durationType),
 	}
 }

--- a/step_logger.go
+++ b/step_logger.go
@@ -11,8 +11,8 @@ type stepLoggerOptions struct {
 	durationType DurationType
 }
 
-func defaultStepLoggerOptions() *stepLoggerOptions {
-	return &stepLoggerOptions{
+func defaultStepLoggerOptions() stepLoggerOptions {
+	return stepLoggerOptions{
 		durationKey:  DurationKeyDefault,
 		durationType: DurationNanoSeconds,
 	}
@@ -23,10 +23,7 @@ type stepLogger struct {
 	durationAttr func(d time.Duration) slog.Attr
 }
 
-func newStepLogger(logger *slog.Logger, opts *stepLoggerOptions) *stepLogger {
-	if opts == nil {
-		opts = defaultStepLoggerOptions()
-	}
+func newStepLogger(logger *slog.Logger, opts stepLoggerOptions) *stepLogger {
 	return &stepLogger{
 		Logger:       logger,
 		durationAttr: durationAttrFunc(opts.durationKey, opts.durationType),

--- a/step_logger_test.go
+++ b/step_logger_test.go
@@ -88,7 +88,7 @@ func TestStepLoggerDurationAttr(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.value.String(), func(t *testing.T) {
 			t.Parallel()
-			attr := newStepLogger(slog.Default(), &stepLoggerOptions{durationKey: key, durationType: tc.durationType}).durationAttr(tc.value)
+			attr := newStepLogger(slog.Default(), stepLoggerOptions{durationKey: key, durationType: tc.durationType}).durationAttr(tc.value)
 			tc.expected(t, attr)
 		})
 	}

--- a/step_logger_test.go
+++ b/step_logger_test.go
@@ -88,7 +88,7 @@ func TestStepLoggerDurationAttr(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.value.String(), func(t *testing.T) {
 			t.Parallel()
-			attr := newStepLogger(&stepLoggerOptions{durationKey: key, durationType: tc.durationType}).durationAttr(tc.value)
+			attr := newStepLogger(slog.Default(), &stepLoggerOptions{durationKey: key, durationType: tc.durationType}).durationAttr(tc.value)
 			tc.expected(t, attr)
 		})
 	}

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -62,7 +62,7 @@ func TestWrapStmt(t *testing.T) {
 
 		buf := bytes.NewBuffer(nil)
 		logger := slog.New(NewJSONHandler(buf, nil))
-		wrapped := wrapStmt(mock, newStepLogger(newStepLoggerOptions(logger)), defaultStmtOptions(StepEventMsgWithoutEventName))
+		wrapped := wrapStmt(mock, newStepLogger(logger, newStepLoggerOptions()), defaultStmtOptions(StepEventMsgWithoutEventName))
 		_, err := wrapped.Query(nil) // nolint:staticcheck
 		if err == nil {
 			t.Fatal("Expected non-nil")
@@ -102,7 +102,7 @@ func TestWithMockErrorStmtWithContext(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 	logger := slog.New(NewJSONHandler(buf, nil))
-	wrapped := wrapStmt(mock, newStepLogger(newStepLoggerOptions(logger)), defaultStmtOptions(StepEventMsgWithoutEventName))
+	wrapped := wrapStmt(mock, newStepLogger(logger, newStepLoggerOptions()), defaultStmtOptions(StepEventMsgWithoutEventName))
 	stmtWithQueryContext, ok := wrapped.(driver.StmtQueryContext)
 	if !ok {
 		t.Fatal("Expected StmtQueryContext")

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -62,7 +62,7 @@ func TestWrapStmt(t *testing.T) {
 
 		buf := bytes.NewBuffer(nil)
 		logger := slog.New(NewJSONHandler(buf, nil))
-		wrapped := wrapStmt(mock, newStepLogger(logger, newStepLoggerOptions()), defaultStmtOptions(StepEventMsgWithoutEventName))
+		wrapped := wrapStmt(mock, newStepLogger(logger, defaultStepLoggerOptions()), defaultStmtOptions(StepEventMsgWithoutEventName))
 		_, err := wrapped.Query(nil) // nolint:staticcheck
 		if err == nil {
 			t.Fatal("Expected non-nil")
@@ -102,7 +102,7 @@ func TestWithMockErrorStmtWithContext(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 	logger := slog.New(NewJSONHandler(buf, nil))
-	wrapped := wrapStmt(mock, newStepLogger(logger, newStepLoggerOptions()), defaultStmtOptions(StepEventMsgWithoutEventName))
+	wrapped := wrapStmt(mock, newStepLogger(logger, defaultStepLoggerOptions()), defaultStmtOptions(StepEventMsgWithoutEventName))
 	stmtWithQueryContext, ok := wrapped.(driver.StmtQueryContext)
 	if !ok {
 		t.Fatal("Expected StmtQueryContext")

--- a/tests/mysql/low_level_with_context_test.go
+++ b/tests/mysql/low_level_with_context_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"os/exec"
 	"testing"
@@ -48,7 +47,7 @@ func TestLowLevelWithContext(t *testing.T) {
 			testhelper.StepEventMsgOptions,
 			sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
 			sqlslog.LogWriter(buf),
-			sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelVerbose}),
+			sqlslog.LogLevel(sqlslog.LevelVerbose),
 			sqlslog.IDGenerator(seqIdGen.Generate),
 			sqlslog.ConnIDKey(connIDKey),
 			sqlslog.StmtIDKey(stmtIDKey),

--- a/tests/mysql/low_level_with_context_test.go
+++ b/tests/mysql/low_level_with_context_test.go
@@ -36,7 +36,6 @@ func TestLowLevelWithContext(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	logs := testhelper.NewLogAssertion(buf)
 	logs.Start()
-	logger := slog.New(sqlslog.NewJSONHandler(buf, &slog.HandlerOptions{Level: sqlslog.LevelVerbose}))
 
 	seqIdGen := testhelper.NewSeqIDGenerator()
 	connIDKey := "conn_id"
@@ -44,10 +43,12 @@ func TestLowLevelWithContext(t *testing.T) {
 	txIDKey := "tx_id"
 	connIDExpected := seqIdGen.Next()
 
-	db, err := sqlslog.Open(ctx, "mysql", "root@tcp(localhost:3306)/"+dbName,
+	db, _, err := sqlslog.Open(ctx, "mysql", "root@tcp(localhost:3306)/"+dbName,
 		append(
 			testhelper.StepEventMsgOptions,
-			sqlslog.Logger(logger),
+			sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
+			sqlslog.LogWriter(buf),
+			sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelVerbose}),
 			sqlslog.IDGenerator(seqIdGen.Generate),
 			sqlslog.ConnIDKey(connIDKey),
 			sqlslog.StmtIDKey(stmtIDKey),

--- a/tests/postgres/low_level_with_context_test.go
+++ b/tests/postgres/low_level_with_context_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"os/exec"
 	"testing"
@@ -46,7 +45,7 @@ func TestLowLevelWithContext(t *testing.T) {
 			testhelper.StepEventMsgOptions,
 			sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
 			sqlslog.LogWriter(buf),
-			sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelVerbose}),
+			sqlslog.LogLevel(sqlslog.LevelVerbose),
 			sqlslog.IDGenerator(seqIdGen.Generate),
 			sqlslog.ConnIDKey(connIDKey),
 			sqlslog.StmtIDKey(stmtIDKey),

--- a/tests/postgres/low_level_with_context_test.go
+++ b/tests/postgres/low_level_with_context_test.go
@@ -35,17 +35,18 @@ func TestLowLevelWithContext(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 	logs := testhelper.NewLogAssertion(buf)
-	logger := slog.New(sqlslog.NewJSONHandler(buf, &slog.HandlerOptions{Level: sqlslog.LevelVerbose}))
 
 	seqIdGen := testhelper.NewSeqIDGenerator()
 	connIDKey := "conn_id"
 	stmtIDKey := "stmt_id"
 	txIDKey := "tx_id"
 
-	db, err := sqlslog.Open(ctx, "postgres", dsn,
+	db, _, err := sqlslog.Open(ctx, "postgres", dsn,
 		append(
 			testhelper.StepEventMsgOptions,
-			sqlslog.Logger(logger),
+			sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
+			sqlslog.LogWriter(buf),
+			sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelVerbose}),
 			sqlslog.IDGenerator(seqIdGen.Generate),
 			sqlslog.ConnIDKey(connIDKey),
 			sqlslog.StmtIDKey(stmtIDKey),

--- a/tests/sqlite3/duration_option_test.go
+++ b/tests/sqlite3/duration_option_test.go
@@ -88,11 +88,12 @@ func TestDuration(t *testing.T) {
 		t.Run(tc.durationKey, func(t *testing.T) {
 			buf := bytes.NewBuffer(nil)
 			logs := testhelper.NewLogAssertion(buf)
-			logger := slog.New(sqlslog.NewJSONHandler(buf, &slog.HandlerOptions{Level: sqlslog.LevelVerbose}))
-			db, err := sqlslog.Open(ctx, "sqlite3", dsn,
+			db, _, err := sqlslog.Open(ctx, "sqlite3", dsn,
 				append(
 					testhelper.StepEventMsgOptions,
-					sqlslog.Logger(logger),
+					sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
+					sqlslog.LogWriter(buf),
+					sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelVerbose}),
 					sqlslog.DurationKey(tc.durationKey),
 					sqlslog.Duration(tc.durationType),
 				)...,

--- a/tests/sqlite3/duration_option_test.go
+++ b/tests/sqlite3/duration_option_test.go
@@ -3,7 +3,6 @@ package main_test
 import (
 	"bytes"
 	"context"
-	"log/slog"
 	"os"
 	"strings"
 	"testing"
@@ -93,7 +92,7 @@ func TestDuration(t *testing.T) {
 					testhelper.StepEventMsgOptions,
 					sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
 					sqlslog.LogWriter(buf),
-					sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelVerbose}),
+					sqlslog.LogLevel(sqlslog.LevelVerbose),
 					sqlslog.DurationKey(tc.durationKey),
 					sqlslog.Duration(tc.durationType),
 				)...,

--- a/tests/sqlite3/low_level_with_context_test.go
+++ b/tests/sqlite3/low_level_with_context_test.go
@@ -25,17 +25,18 @@ func TestLowLevelWithContext(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 	logs := testhelper.NewLogAssertion(buf)
-	logger := slog.New(sqlslog.NewJSONHandler(buf, &slog.HandlerOptions{Level: sqlslog.LevelVerbose}))
 
 	seqIdGen := testhelper.NewSeqIDGenerator()
 	connIDKey := "conn_id"
 	stmtIDKey := "stmt_id"
 	txIDKey := "tx_id"
 
-	db, err := sqlslog.Open(ctx, "sqlite3", dsn,
+	db, _, err := sqlslog.Open(ctx, "sqlite3", dsn,
 		append(
 			testhelper.StepEventMsgOptions,
-			sqlslog.Logger(logger),
+			sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
+			sqlslog.LogWriter(buf),
+			sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelVerbose}),
 			sqlslog.IDGenerator(seqIdGen.Generate),
 			sqlslog.ConnIDKey(connIDKey),
 			sqlslog.StmtIDKey(stmtIDKey),

--- a/tests/sqlite3/low_level_with_context_test.go
+++ b/tests/sqlite3/low_level_with_context_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -36,7 +35,7 @@ func TestLowLevelWithContext(t *testing.T) {
 			testhelper.StepEventMsgOptions,
 			sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
 			sqlslog.LogWriter(buf),
-			sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelVerbose}),
+			sqlslog.LogLevel(sqlslog.LevelVerbose),
 			sqlslog.IDGenerator(seqIdGen.Generate),
 			sqlslog.ConnIDKey(connIDKey),
 			sqlslog.StmtIDKey(stmtIDKey),

--- a/tests/sqlite3/low_level_without_context_test.go
+++ b/tests/sqlite3/low_level_without_context_test.go
@@ -25,17 +25,18 @@ func TestLowLevelWithoutContext(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 	logs := testhelper.NewLogAssertion(buf)
-	logger := slog.New(sqlslog.NewJSONHandler(buf, &slog.HandlerOptions{Level: sqlslog.LevelVerbose}))
 
 	seqIdGen := testhelper.NewSeqIDGenerator()
 	connIDKey := "conn_id"
 	stmtIDKey := "stmt_id"
 	txIDKey := "tx_id"
 
-	db, err := sqlslog.Open(ctx, "sqlite3", dsn,
+	db, _, err := sqlslog.Open(ctx, "sqlite3", dsn,
 		append(
 			testhelper.StepEventMsgOptions,
-			sqlslog.Logger(logger),
+			sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
+			sqlslog.LogWriter(buf),
+			sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelVerbose}),
 			sqlslog.IDGenerator(seqIdGen.Generate),
 			sqlslog.ConnIDKey(connIDKey),
 			sqlslog.StmtIDKey(stmtIDKey),

--- a/tests/sqlite3/low_level_without_context_test.go
+++ b/tests/sqlite3/low_level_without_context_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -36,7 +35,7 @@ func TestLowLevelWithoutContext(t *testing.T) {
 			testhelper.StepEventMsgOptions,
 			sqlslog.HandlerFunc(sqlslog.NewJSONHandler),
 			sqlslog.LogWriter(buf),
-			sqlslog.HandlerOptions(&slog.HandlerOptions{Level: sqlslog.LevelVerbose}),
+			sqlslog.LogLevel(sqlslog.LevelVerbose),
 			sqlslog.IDGenerator(seqIdGen.Generate),
 			sqlslog.ConnIDKey(connIDKey),
 			sqlslog.StmtIDKey(stmtIDKey),


### PR DESCRIPTION
## Breaking Change

- sqlslog.Open function
    - Returns *sql.DB, *slog.Logger and error instead of *sql.DB and error

## New features

- New function returns *Factory which has the following methods
    - Open
    - Handler 
    - Logger
- ParseLevel and ParseLevelWithDefault function

## Example Changes

- Add verbose-logs.json file into examples/logs-*/results

## Inslide changes

1. newStepLogger requires *slog.Logger as first argument

## Test changes

1. Define MockDriver for tests in top-level
2. Add removeTimeAndDuration function for tests
3. Add examples with `Output:` to work as test

## linters

- Enable [usetesting](https://github.com/subtlewrinkl/usetesting) instead of tenv deprecated
- Disalbe forcetypeassert in tests
